### PR TITLE
Add `--variables` deploy flag and `variables` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ spin plugin install --url https://github.com/fermyon/cloud-plugin/releases/downl
     tar -czvf cloud.tar.gz cloud
     sha256sum cloud.tar.gz
     rm cloud
-    # Update cloud.json with shasum
+    # Outputs a shasum to add to cloud.json
     ```
 
 1. Get the manifest.
@@ -27,7 +27,7 @@ spin plugin install --url https://github.com/fermyon/cloud-plugin/releases/downl
     curl -LRO https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json
     ```
 
-1. Update the manifest to modify the `url` field to point to the path to local package (i.e. `"url": "file:///path/to/cloud-plugin/plugin/cloud.tar.gz"`).
+1. Update the manifest to modify the `url` field to point to the path to local package (i.e. `"url": "file:///path/to/cloud-plugin/plugin/cloud.tar.gz"`) and update the shasum.
 
 1. Install the plugin, pointing to the path to the manifest.
 

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -12,13 +12,14 @@ use cloud_openapi::{
         device_codes_api::api_device_codes_post,
         key_value_pairs_api::api_key_value_pairs_post,
         revisions_api::{api_revisions_get, api_revisions_post},
+        variable_pairs_api::api_variable_pairs_post,
         Error, ResponseContent,
     },
     models::{
         AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy,
         CreateAppCommand, CreateChannelCommand, CreateDeviceCodeCommand, CreateKeyValuePairCommand,
-        DeviceCodeItem, GetChannelLogsVm, RefreshTokenCommand, RegisterRevisionCommand,
-        RevisionItemPage, TokenInfo, UpdateEnvironmentVariableDto,
+        CreateVariablePairCommand, DeviceCodeItem, GetChannelLogsVm, RefreshTokenCommand,
+        RegisterRevisionCommand, RevisionItemPage, TokenInfo, UpdateEnvironmentVariableDto,
     },
 };
 use reqwest::header;
@@ -326,6 +327,25 @@ impl Client {
                 app_id,
                 store_name,
                 key,
+                value,
+            },
+            None,
+        )
+        .await
+        .map_err(format_response_error)
+    }
+
+    pub async fn add_variable_pair(
+        &self,
+        app_id: Uuid,
+        variable: String,
+        value: String,
+    ) -> anyhow::Result<()> {
+        api_variable_pairs_post(
+            &self.configuration,
+            CreateVariablePairCommand {
+                app_id,
+                variable,
                 value,
             },
             None,

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -40,9 +40,9 @@ const SPIN_DEPLOY_CHANNEL_NAME: &str = "spin-deploy";
 const SPIN_DEFAULT_KV_STORE: &str = "default";
 const BINDLE_REGISTRY_URL_PATH: &str = "api/registry";
 
-/// Package and upload an application to the Fermyon Platform.
+/// Package and upload an application to the Fermyon Cloud.
 #[derive(Parser, Debug)]
-#[clap(about = "Package and upload an application to the Fermyon Platform")]
+#[clap(about = "Package and upload an application to the Fermyon Cloud")]
 pub struct DeployCommand {
     /// The application to deploy. This may be a manifest (spin.toml) file, or a
     /// directory containing a spin.toml file.

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -32,7 +32,7 @@ use std::{
 use url::Url;
 use uuid::Uuid;
 
-use crate::{opts::*, parse_buildinfo};
+use crate::{commands::variables::set_variables, opts::*, parse_buildinfo};
 
 use super::login::{LoginCommand, LoginConnection};
 
@@ -105,118 +105,17 @@ pub struct DeployCommand {
     /// Can be used multiple times.
     #[clap(long = "key-value", parse(try_from_str = parse_kv))]
     pub key_values: Vec<(String, String)>,
+
+    /// Set a variable pair (variable=value) in the deployed application.
+    /// Any existing value will be overwritten.
+    /// Can be used multiple times.
+    #[clap(long = "variable", parse(try_from_str = parse_kv))]
+    pub variables: Vec<(String, String)>,
 }
 
 impl DeployCommand {
     pub async fn run(self) -> Result<()> {
-        let path = self.config_file_path()?;
-
-        // log in if config.json does not exist or cannot be read
-        let data = match fs::read_to_string(path.clone()).await {
-            Ok(d) => d,
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                match self.deployment_env_id {
-                    Some(name) => {
-                        // TODO: allow auto redirect to login preserving the name
-                        eprintln!("You have no instance saved as '{}'", name);
-                        eprintln!("Run `spin login --environment-name {}` to log in", name);
-                        std::process::exit(1);
-                    }
-                    None => {
-                        // log in, then read config
-                        // TODO: propagate deployment id (or bail if nondefault?)
-                        LoginCommand::parse_from(vec!["login"]).run().await?;
-                        fs::read_to_string(path.clone()).await?
-                    }
-                }
-            }
-            Err(e) => {
-                bail!("Could not log in: {}", e);
-            }
-        };
-
-        let mut login_connection: LoginConnection = serde_json::from_str(&data)?;
-        let expired = match has_expired(&login_connection) {
-            Ok(val) => val,
-            Err(err) => {
-                eprintln!("{}\n", err);
-                eprintln!("Run `spin login` to log in again");
-                std::process::exit(1);
-            }
-        };
-
-        if expired {
-            // if we have a refresh token available, let's try to refresh the token
-            match login_connection.refresh_token {
-                Some(refresh_token) => {
-                    // Only Cloud has support for refresh tokens
-                    let connection_config = ConnectionConfig {
-                        url: login_connection.url.to_string(),
-                        insecure: login_connection.danger_accept_invalid_certs,
-                        token: login_connection.token.clone(),
-                    };
-                    let client = CloudClient::new(connection_config.clone());
-
-                    match client
-                        .refresh_token(login_connection.token, refresh_token)
-                        .await
-                    {
-                        Ok(token_info) => {
-                            login_connection.token = token_info.token;
-                            login_connection.refresh_token = Some(token_info.refresh_token);
-                            login_connection.expiration = Some(token_info.expiration);
-                            // save new token info
-                            let path = self.config_file_path()?;
-                            std::fs::write(path, serde_json::to_string_pretty(&login_connection)?)?;
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to refresh token: {}", e);
-                            match self.deployment_env_id {
-                                Some(name) => {
-                                    eprintln!(
-                                        "Run `spin login --environment-name {}` to log in again",
-                                        name
-                                    );
-                                }
-                                None => {
-                                    eprintln!("Run `spin login` to log in again");
-                                }
-                            }
-                            std::process::exit(1);
-                        }
-                    }
-                }
-                None => {
-                    // session has expired and we have no way to refresh the token - log back in
-                    match self.deployment_env_id {
-                        Some(name) => {
-                            // TODO: allow auto redirect to login preserving the name
-                            eprintln!("Your login to this environment has expired");
-                            eprintln!(
-                                "Run `spin login --environment-name {}` to log in again",
-                                name
-                            );
-                            std::process::exit(1);
-                        }
-                        None => {
-                            LoginCommand::parse_from(vec!["login"]).run().await?;
-                            let new_data = fs::read_to_string(path.clone()).await.context(
-                                format!("Cannot find spin config at {}", path.to_string_lossy()),
-                            )?;
-                            login_connection = serde_json::from_str(&new_data)?;
-                        }
-                    }
-                }
-            }
-        }
-
-        let sloth_guard = sloth::warn_if_slothful(
-            2500,
-            format!("Checking status ({})\n", login_connection.url),
-        );
-        check_healthz(&login_connection.url).await?;
-        // Server has responded - we don't want to keep the sloth timer running.
-        drop(sloth_guard);
+        let login_connection = login_connection(self.deployment_env_id.as_deref()).await?;
 
         const DEVELOPER_CLOUD_FAQ: &str = "https://developer.fermyon.com/cloud/faq";
 
@@ -227,23 +126,6 @@ impl DeployCommand {
 
     fn app(&self) -> anyhow::Result<PathBuf> {
         crate::manifest::resolve_file_path(&self.app_source)
-    }
-
-    // TODO: unify with login
-    fn config_file_path(&self) -> Result<PathBuf> {
-        let root = dirs::config_dir()
-            .context("Cannot find configuration directory")?
-            .join("fermyon");
-
-        let file_stem = match &self.deployment_env_id {
-            None => "config",
-            Some(id) => id,
-        };
-        let file = format!("{}.json", file_stem);
-
-        let path = root.join(file);
-
-        Ok(path)
     }
 
     async fn deploy_cloud(self, login_connection: LoginConnection) -> Result<()> {
@@ -332,6 +214,8 @@ impl DeployCommand {
                     .context("Problem creating key/value")?;
                 }
 
+                set_variables(&client, app_id, &self.variables).await?;
+
                 existing_channel_id
             }
             Err(_) => {
@@ -368,6 +252,8 @@ impl DeployCommand {
                     .await
                     .context("Problem creating key/value")?;
                 }
+
+                set_variables(&client, app_id, &self.variables).await?;
 
                 channel_id
             }
@@ -714,4 +600,144 @@ fn has_expired(login_connection: &LoginConnection) -> Result<bool> {
         },
         None => Ok(false),
     }
+}
+
+pub async fn login_connection(deployment_env_id: Option<&str>) -> Result<LoginConnection> {
+    let path = config_file_path(deployment_env_id)?;
+
+    // log in if config.json does not exist or cannot be read
+    let data = match fs::read_to_string(path.clone()).await {
+        Ok(d) => d,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            match deployment_env_id {
+                Some(name) => {
+                    // TODO: allow auto redirect to login preserving the name
+                    eprintln!("You have no instance saved as '{}'", name);
+                    eprintln!("Run `spin login --environment-name {}` to log in", name);
+                    std::process::exit(1);
+                }
+                None => {
+                    // log in, then read config
+                    // TODO: propagate deployment id (or bail if nondefault?)
+                    LoginCommand::parse_from(vec!["login"]).run().await?;
+                    fs::read_to_string(path.clone()).await?
+                }
+            }
+        }
+        Err(e) => {
+            bail!("Could not log in: {}", e);
+        }
+    };
+
+    let mut login_connection: LoginConnection = serde_json::from_str(&data)?;
+    let expired = match has_expired(&login_connection) {
+        Ok(val) => val,
+        Err(err) => {
+            eprintln!("{}\n", err);
+            eprintln!("Run `spin login` to log in again");
+            std::process::exit(1);
+        }
+    };
+
+    if expired {
+        // if we have a refresh token available, let's try to refresh the token
+        match login_connection.refresh_token {
+            Some(refresh_token) => {
+                // Only Cloud has support for refresh tokens
+                let connection_config = ConnectionConfig {
+                    url: login_connection.url.to_string(),
+                    insecure: login_connection.danger_accept_invalid_certs,
+                    token: login_connection.token.clone(),
+                };
+                let client = CloudClient::new(connection_config.clone());
+
+                match client
+                    .refresh_token(login_connection.token, refresh_token)
+                    .await
+                {
+                    Ok(token_info) => {
+                        login_connection.token = token_info.token;
+                        login_connection.refresh_token = Some(token_info.refresh_token);
+                        login_connection.expiration = Some(token_info.expiration);
+                        // save new token info
+                        let path = config_file_path(deployment_env_id)?;
+                        std::fs::write(path, serde_json::to_string_pretty(&login_connection)?)?;
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to refresh token: {}", e);
+                        match deployment_env_id {
+                            Some(name) => {
+                                eprintln!(
+                                    "Run `spin login --environment-name {}` to log in again",
+                                    name
+                                );
+                            }
+                            None => {
+                                eprintln!("Run `spin login` to log in again");
+                            }
+                        }
+                        std::process::exit(1);
+                    }
+                }
+            }
+            None => {
+                // session has expired and we have no way to refresh the token - log back in
+                match deployment_env_id {
+                    Some(name) => {
+                        // TODO: allow auto redirect to login preserving the name
+                        eprintln!("Your login to this environment has expired");
+                        eprintln!(
+                            "Run `spin login --environment-name {}` to log in again",
+                            name
+                        );
+                        std::process::exit(1);
+                    }
+                    None => {
+                        LoginCommand::parse_from(vec!["login"]).run().await?;
+                        let new_data = fs::read_to_string(path.clone()).await.context(format!(
+                            "Cannot find spin config at {}",
+                            path.to_string_lossy()
+                        ))?;
+                        login_connection = serde_json::from_str(&new_data)?;
+                    }
+                }
+            }
+        }
+    }
+
+    let sloth_guard = sloth::warn_if_slothful(
+        2500,
+        format!("Checking status ({})\n", login_connection.url),
+    );
+    check_healthz(&login_connection.url).await?;
+    // Server has responded - we don't want to keep the sloth timer running.
+    drop(sloth_guard);
+
+    Ok(login_connection)
+}
+
+pub async fn get_app_id_cloud(cloud_client: &CloudClient, name: String) -> Result<Uuid> {
+    let apps_vm = CloudClient::list_apps(cloud_client).await?;
+    let app = apps_vm.items.iter().find(|&x| x.name == name.clone());
+    match app {
+        Some(a) => Ok(a.id),
+        None => bail!("No app with name: {}", name),
+    }
+}
+
+// TODO: unify with login
+pub fn config_file_path(deployment_env_id: Option<&str>) -> Result<PathBuf> {
+    let root = dirs::config_dir()
+        .context("Cannot find configuration directory")?
+        .join("fermyon");
+
+    let file_stem = match deployment_env_id {
+        None => "config",
+        Some(id) => id,
+    };
+    let file = format!("{}.json", file_stem);
+
+    let path = root.join(file);
+
+    Ok(path)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod deploy;
 pub mod login;
+pub mod variables;

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -1,0 +1,66 @@
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use cloud::client::{Client as CloudClient, ConnectionConfig};
+use spin_common::arg_parser::parse_kv;
+use uuid::Uuid;
+
+use crate::{
+    commands::deploy::{get_app_id_cloud, login_connection},
+    opts::*,
+};
+
+/// Manage Spin application variables
+#[derive(Parser, Debug)]
+#[clap(about = "Log into the Fermyon Platform")]
+pub struct VariablesCommand {
+    /// Variable pair to set
+    #[clap(name = VARIABLES_SET_OPT, short = 's', long = "set", parse(try_from_str = parse_kv))]
+    pub variables_to_set: Vec<(String, String)>,
+
+    /// Deploy to the Fermyon instance saved under the specified name.
+    /// If omitted, Spin deploys to the default unnamed instance.
+    #[clap(
+        name = "environment-name",
+        long = "environment-name",
+        env = DEPLOYMENT_ENV_NAME_ENV
+    )]
+    pub deployment_env_id: Option<String>,
+
+    /// Name of Spin app
+    #[clap(name = "app", long = "app")]
+    pub app: String,
+}
+
+impl VariablesCommand {
+    pub async fn run(self) -> Result<()> {
+        let login_connection = login_connection(self.deployment_env_id.as_deref()).await?;
+
+        let connection_config = ConnectionConfig {
+            url: login_connection.url.to_string(),
+            insecure: login_connection.danger_accept_invalid_certs,
+            token: login_connection.token.clone(),
+        };
+
+        let client = CloudClient::new(connection_config.clone());
+
+        let app_id = get_app_id_cloud(&client, self.app.clone())
+            .await
+            .with_context(|| anyhow!(format!("Could not find app_id for app {}", self.app)))?;
+
+        set_variables(&client, app_id, &self.variables_to_set).await?;
+        Ok(())
+    }
+}
+
+pub(crate) async fn set_variables(
+    client: &CloudClient,
+    app_id: Uuid,
+    variables: &[(String, String)],
+) -> Result<()> {
+    for var in variables {
+        CloudClient::add_variable_pair(client, app_id, var.0.to_owned(), var.1.to_owned())
+            .await
+            .context("Problem creating variable")?;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod manifest;
 mod opts;
 use anyhow::{anyhow, Error, Result};
 use clap::{Parser, Subcommand};
-use commands::{deploy::DeployCommand, login::LoginCommand};
+use commands::{deploy::DeployCommand, login::LoginCommand, variables::VariablesCommand};
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
 use std::path::Path;
@@ -22,6 +22,8 @@ enum Commands {
     Deploy(DeployCommand),
     /// Login to Fermyon Cloud
     Login(LoginCommand),
+    /// Manage Spin application variables
+    Variables(VariablesCommand),
 }
 
 #[tokio::main]
@@ -33,6 +35,7 @@ async fn main() -> Result<(), Error> {
     match cli.command {
         Commands::Deploy(cmd) => cmd.run().await,
         Commands::Login(cmd) => cmd.run().await,
+        Commands::Variables(cmd) => cmd.run().await,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod commands;
 mod manifest;
 mod opts;
 use anyhow::{anyhow, Error, Result};
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use commands::{deploy::DeployCommand, login::LoginCommand, variables::VariablesCommand};
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
@@ -11,31 +11,24 @@ use std::path::Path;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
-struct Cli {
-    #[clap(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Package and upload an application to Fermyon Cloud.
+enum CloudCli {
+    /// Package and upload an application to the Fermyon Cloud.
     Deploy(DeployCommand),
     /// Login to Fermyon Cloud
     Login(LoginCommand),
     /// Manage Spin application variables
+    #[clap(subcommand, alias = "vars")]
     Variables(VariablesCommand),
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let cli = Cli::parse();
+    let cli = CloudCli::parse();
 
-    // You can check for the existence of subcommands, and if found use their
-    // matches just as you would the top level cmd
-    match cli.command {
-        Commands::Deploy(cmd) => cmd.run().await,
-        Commands::Login(cmd) => cmd.run().await,
-        Commands::Variables(cmd) => cmd.run().await,
+    match cli {
+        CloudCli::Deploy(cmd) => cmd.run().await,
+        CloudCli::Login(cmd) => cmd.run().await,
+        CloudCli::Variables(cmd) => cmd.run().await,
     }
 }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -8,3 +8,4 @@ pub const CLOUD_URL_ENV: &str = "CLOUD_URL";
 pub const DEPLOYMENT_ENV_NAME_ENV: &str = "FERMYON_DEPLOYMENT_ENVIRONMENT";
 pub const TOKEN: &str = "TOKEN";
 pub const SPIN_AUTH_TOKEN: &str = "SPIN_AUTH_TOKEN";
+pub const VARIABLES_SET_OPT: &str = "SET";


### PR DESCRIPTION
- Draft because i am not sure if we want to wait to merge this once we flip this feature on and whether the cloud plugin will come before config vars
- Moves most of the body of the DeployCommand's `run` function into a sharable `login_connection` function that will likely be used by most subcommands.
- Identifies an app by app manifest `name`

## Example
App with the following manifest:
```toml
spin_manifest_version = "1"
authors = ["Fermyon Engineering <engineering@fermyon.com>"]
description = "A simple application that returns hello."
name = "variables-plugin"
trigger = { type = "http", base = "/" }
version = "1.0.0"

[variables]
host = {required = true}

[[component]]
id = "hello"
source = "target/wasm32-wasi/release/http_rust.wasm"
description = "A simple component that returns hello."
[component.trigger]
route = "/hello"
[component.config]
host = "{{ host }}"
[component.build]
command = "cargo build --target wasm32-wasi --release"
```
and handle
```rust
#[http_component]
fn hello_world(req: Request) -> Result<Response> {
    let host = config::get("host")?;
    Ok(http::Response::builder()
        .status(200)
        .header("foo", "bar")
        .body(Some(format!("Hello, {host}\n").into()))?)
}
```

Can deploy it with a config variable and then update it. I'm using the [cloud plugin version of Spin from this PR](https://github.com/fermyon/spin/pull/1452).

```bash
cargo run -- deploy --variable host=wowzee  --from examples/http-rust 
# Hello, wowzee
cargo run -- cloud variables set host=yippee unused=value --app variables-plugin
# Hello, yippee
```
