### PR TITLE
Make plugin manifest description consistent with Spin command description

### DIFF
--- a/.plugin-manifests/generate-manifest.sh
+++ b/.plugin-manifests/generate-manifest.sh
@@ -33,7 +33,7 @@ WINDOWS_AMD=$(cat $2 | grep "windows-amd64" | awk '{print $1}')
 cat <<EOF 
 {
   "name": "cloud",
-  "description": "The Fermyon Cloud Plugin",
+  "description": "Commands for publishing applications to the Fermyon Cloud.",
   "homepage": "https://github.com/fermyon/cloud-plugin",
   "version": "${VERSION//v}",
   "spinCompatibility": "${SPIN_COMPAT_STRING}",

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -110,7 +110,7 @@ pub struct DeployCommand {
     #[clap(long = "key-value", parse(try_from_str = parse_kv))]
     pub key_values: Vec<(String, String)>,
 
-    /// Set a variable pair (variable=value) in the deployed application.
+    /// Set a variable (variable=value) in the deployed application.
     /// Any existing value will be overwritten.
     /// Can be used multiple times.
     #[clap(long = "variable", parse(try_from_str = parse_kv), hide = true)]

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -20,9 +20,9 @@ struct Variable {
 #[derive(Parser, Debug)]
 #[clap(about = "Manage Spin application variables")]
 pub enum VariablesCommand {
-    /// Set variable pairs
+    /// Set variables
     Set(SetCommand),
-    /// Delete variable pairs
+    /// Delete variables
     Delete(DeleteCommand),
     /// List all variables of an application
     List(ListCommand),


### PR DESCRIPTION
In `spin --help`, the `cloud` command has the help text "Commands for publishing applications to the Fermyon Cloud."  This seems like a good description for the plugin too, and will avoid the help text changing after installation if https://github.com/fermyon/spin/pull/1560 gets implemented.