### PR TITLE
Update CLI to set binary name to Spin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod commands;
 mod manifest;
 mod opts;
 use anyhow::{anyhow, Error, Result};
-use clap::Parser;
+use clap::{FromArgMatches, Parser};
 use commands::{deploy::DeployCommand, login::LoginCommand, variables::VariablesCommand};
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
@@ -23,7 +23,11 @@ enum CloudCli {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let cli = CloudCli::parse();
+    let mut app = CloudCli::clap();
+    // Plugin should always be invoked from Spin so set binary name accordingly
+    app.set_bin_name("spin cloud");
+    let matches = app.get_matches();
+    let cli = CloudCli::from_arg_matches(&matches)?;
 
     match cli {
         CloudCli::Deploy(cmd) => cmd.run().await,


### PR DESCRIPTION
closes fermyon/spin#1601 by naming the binary Spin even if invoked separately

```sh
$ cloud --help
spin-cloud 0.1.1
Fermyon Engineering <engineering@fermyon.com>

USAGE:
    spin cloud <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    deploy       Package and upload an application to the Fermyon Cloud
    help         Print this message or the help of the given subcommand(s)
    login        Login to Fermyon Cloud
    variables    Manage Spin application variables
```