### PR TITLE
`sqlite` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "cloud-openapi"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/cloud-openapi?rev=98e7bd2ca97eab25c88dae5d6c65609577d36992#98e7bd2ca97eab25c88dae5d6c65609577d36992"
+source = "git+https://github.com/kate-goldenring/cloud-openapi?rev=5b02f49d8e78c4c246224bdc6b7cdb88c5747758#5b02f49d8e78c4c246224bdc6b7cdb88c5747758"
 dependencies = [
  "reqwest",
  "serde",
@@ -463,6 +463,7 @@ dependencies = [
  "clap",
  "cloud",
  "cloud-openapi",
+ "dialoguer",
  "dirs 5.0.1",
  "openssl",
  "rand 0.8.5",
@@ -483,6 +484,19 @@ dependencies = [
  "url",
  "uuid",
  "vergen",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -813,6 +827,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +959,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2619,6 +2651,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shellexpand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "cloud-openapi"
 version = "0.1.0"
-source = "git+https://github.com/kate-goldenring/cloud-openapi?rev=5b02f49d8e78c4c246224bdc6b7cdb88c5747758#5b02f49d8e78c4c246224bdc6b7cdb88c5747758"
+source = "git+https://github.com/fermyon/cloud-openapi?rev=dbf4657ef4e70433aea17210a539202443e2ce96#dbf4657ef4e70433aea17210a539202443e2ce96"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-fe
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 cloud = { path = "crates/cloud" }
-cloud-openapi = { git = "https://github.com/kate-goldenring/cloud-openapi", rev = "5b02f49d8e78c4c246224bdc6b7cdb88c5747758" }
+cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "dbf4657ef4e70433aea17210a539202443e2ce96" }
 dirs = "5.0"
 dialoguer = "0.10"
 tokio = { version = "1.23", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ bindle = { git = "https://github.com/fermyon/bindle", tag = "v0.8.2", default-fe
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 cloud = { path = "crates/cloud" }
-cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "98e7bd2ca97eab25c88dae5d6c65609577d36992" }
+cloud-openapi = { git = "https://github.com/kate-goldenring/cloud-openapi", rev = "5b02f49d8e78c4c246224bdc6b7cdb88c5747758" }
 dirs = "5.0"
+dialoguer = "0.10"
 tokio = { version = "1.23", features = ["full"] }
 tracing = { workspace = true }
 rand = "0.8"

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
-cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "98e7bd2ca97eab25c88dae5d6c65609577d36992" }
+cloud-openapi = { git = "https://github.com/kate-goldenring/cloud-openapi", rev = "5b02f49d8e78c4c246224bdc6b7cdb88c5747758" }
 mime_guess = { version = "2.0" }
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
-cloud-openapi = { git = "https://github.com/kate-goldenring/cloud-openapi", rev = "5b02f49d8e78c4c246224bdc6b7cdb88c5747758" }
+cloud-openapi = { git = "https://github.com/fermyon/cloud-openapi", rev = "dbf4657ef4e70433aea17210a539202443e2ce96" }
 mime_guess = { version = "2.0" }
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -860,9 +860,9 @@ pub async fn login_connection(deployment_env_id: Option<&str>) -> Result<LoginCo
     Ok(login_connection)
 }
 
-pub async fn get_app_id_cloud(cloud_client: &CloudClient, name: String) -> Result<Uuid> {
+pub async fn get_app_id_cloud(cloud_client: &CloudClient, name: &str) -> Result<Uuid> {
     let apps_vm = CloudClient::list_apps(cloud_client).await?;
-    let app = apps_vm.items.iter().find(|&x| x.name == name.clone());
+    let app = apps_vm.items.iter().find(|&x| x.name == name);
     match app {
         Some(a) => Ok(a.id),
         None => bail!("No app with name: {}", name),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,18 @@
 pub mod deploy;
 pub mod login;
+pub mod sql;
 pub mod variables;
+
+use crate::commands::deploy::login_connection;
+use anyhow::Result;
+use cloud::client::{Client as CloudClient, ConnectionConfig};
+
+pub(crate) async fn create_cloud_client(deployment_env_id: Option<&str>) -> Result<CloudClient> {
+    let login_connection = login_connection(deployment_env_id).await?;
+    let connection_config = ConnectionConfig {
+        url: login_connection.url.to_string(),
+        insecure: login_connection.danger_accept_invalid_certs,
+        token: login_connection.token,
+    };
+    Ok(CloudClient::new(connection_config))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 pub mod deploy;
 pub mod login;
-pub mod sql;
+pub mod sqlite;
 pub mod variables;
 
 use crate::commands::deploy::login_connection;

--- a/src/commands/sql.rs
+++ b/src/commands/sql.rs
@@ -10,21 +10,10 @@ use crate::opts::*;
 #[derive(Parser, Debug)]
 #[clap(about = "Manage Fermyon Cloud SQL databases")]
 pub enum SqlCommand {
-    /// Create a SQL database
-    #[clap(hide = true)]
-    Create(CreateCommand),
     /// Delete a SQL database
     Delete(DeleteCommand),
     /// List all SQL databases of a user
     List(ListCommand),
-}
-
-#[derive(Parser, Debug)]
-pub struct CreateCommand {
-    /// Name of database to create
-    name: String,
-    #[clap(flatten)]
-    common: CommonArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -56,12 +45,6 @@ struct CommonArgs {
 impl SqlCommand {
     pub async fn run(self) -> Result<()> {
         match self {
-            Self::Create(cmd) => {
-                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
-                CloudClient::create_database(&client, None, cmd.name.clone())
-                    .await
-                    .with_context(|| format!("Problem creating database {}", cmd.name))?;
-            }
             Self::Delete(cmd) => {
                 let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
                 CloudClient::delete_database(&client, cmd.name.clone())

--- a/src/commands/sql.rs
+++ b/src/commands/sql.rs
@@ -1,0 +1,92 @@
+use anyhow::{Context, Result};
+use clap::{Args, Parser};
+use cloud::client::Client as CloudClient;
+use cloud_openapi::models::Database;
+
+use crate::commands::create_cloud_client;
+use crate::opts::*;
+
+/// Manage Fermyon Cloud SQL databases
+#[derive(Parser, Debug)]
+#[clap(about = "Manage Fermyon Cloud SQL databases")]
+pub enum SqlCommand {
+    /// Create a SQL database
+    #[clap(hide = true)]
+    Create(CreateCommand),
+    /// Delete a SQL database
+    Delete(DeleteCommand),
+    /// List all SQL databases of a user
+    List(ListCommand),
+}
+
+#[derive(Parser, Debug)]
+pub struct CreateCommand {
+    /// Name of database to create
+    name: String,
+    #[clap(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct DeleteCommand {
+    /// Name of database to create
+    name: String,
+    #[clap(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct ListCommand {
+    #[clap(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Debug, Default, Args)]
+struct CommonArgs {
+    /// Deploy to the Fermyon instance saved under the specified name.
+    /// If omitted, Spin deploys to the default unnamed instance.
+    #[clap(
+        name = "environment-name",
+        long = "environment-name",
+        env = DEPLOYMENT_ENV_NAME_ENV
+    )]
+    pub deployment_env_id: Option<String>,
+}
+
+impl SqlCommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            Self::Create(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                CloudClient::create_database(&client, None, cmd.name.clone())
+                    .await
+                    .with_context(|| format!("Problem creating database {}", cmd.name))?;
+            }
+            Self::Delete(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                CloudClient::delete_database(&client, cmd.name.clone())
+                    .await
+                    .with_context(|| format!("Problem deleting database {}", cmd.name))?;
+            }
+            Self::List(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                list_databases(&client).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_databases(databases: Vec<Database>) {
+    for d in databases {
+        let default_str = if d.default { "(default)" } else { "" };
+        println!("{}{default_str}", d.name);
+    }
+}
+
+pub(crate) async fn list_databases(client: &CloudClient) -> Result<()> {
+    let list: Vec<cloud_openapi::models::Database> =
+        CloudClient::get_databases(client, None).await?;
+    print_databases(list);
+    Ok(())
+}

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -6,13 +6,13 @@ use cloud_openapi::models::Database;
 use crate::commands::create_cloud_client;
 use crate::opts::*;
 
-/// Manage Fermyon Cloud SQL databases
+/// Manage Fermyon Cloud SQLite databases
 #[derive(Parser, Debug)]
-#[clap(about = "Manage Fermyon Cloud SQL databases")]
-pub enum SqlCommand {
-    /// Delete a SQL database
+#[clap(about = "Manage Fermyon Cloud SQLite databases")]
+pub enum SqliteCommand {
+    /// Delete a SQLite database
     Delete(DeleteCommand),
-    /// List all SQL databases of a user
+    /// List all SQLite databases of a user
     List(ListCommand),
 }
 
@@ -42,7 +42,7 @@ struct CommonArgs {
     pub deployment_env_id: Option<String>,
 }
 
-impl SqlCommand {
+impl SqliteCommand {
     pub async fn run(self) -> Result<()> {
         match self {
             Self::Delete(cmd) => {

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -1,15 +1,14 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use clap::{Args, Parser};
-use cloud::client::{Client as CloudClient, ConnectionConfig};
+use cloud::client::Client as CloudClient;
 use serde::Deserialize;
 use serde_json::from_str;
 use spin_common::arg_parser::parse_kv;
 use uuid::Uuid;
 
-use crate::{
-    commands::deploy::{get_app_id_cloud, login_connection},
-    opts::*,
-};
+use crate::opts::*;
+
+use crate::commands::{create_cloud_client, deploy::get_app_id_cloud};
 
 #[derive(Deserialize)]
 pub(crate) struct Variable {
@@ -67,48 +66,26 @@ struct CommonArgs {
     pub app: String,
 }
 
-/// Information needed to connect to Fermyon Cloud to manage a specific Spin application
-struct AppManagmentInfo {
-    app_id: Uuid,
-    client: CloudClient,
-}
-
-impl AppManagmentInfo {
-    pub async fn new(deployment_env_id: Option<&str>, app: &str) -> Result<Self> {
-        let login_connection = login_connection(deployment_env_id).await?;
-        let connection_config = ConnectionConfig {
-            url: login_connection.url.to_string(),
-            insecure: login_connection.danger_accept_invalid_certs,
-            token: login_connection.token.clone(),
-        };
-        let client = CloudClient::new(connection_config.clone());
-        let app_id = get_app_id_cloud(&client, app.to_string())
-            .await
-            .with_context(|| anyhow!(format!("Could not find app_id for app {}", app)))?;
-        Ok(AppManagmentInfo { app_id, client })
-    }
-}
-
 impl VariablesCommand {
     pub async fn run(self) -> Result<()> {
         match self {
             Self::Set(cmd) => {
-                let info =
-                    AppManagmentInfo::new(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
+                let (client, app_id) =
+                    client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
                         .await?;
-                set_variables(&info.client, info.app_id, &cmd.variables_to_set).await?;
+                set_variables(&client, app_id, &cmd.variables_to_set).await?;
             }
             Self::Delete(cmd) => {
-                let info =
-                    AppManagmentInfo::new(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
+                let (client, app_id) =
+                    client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
                         .await?;
-                delete_variables(&info.client, info.app_id, &cmd.variables_to_delete).await?;
+                delete_variables(&client, app_id, &cmd.variables_to_delete).await?;
             }
             Self::List(cmd) => {
-                let info =
-                    AppManagmentInfo::new(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
+                let (client, app_id) =
+                    client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.common.app)
                         .await?;
-                let var_names = get_variables(&info.client, info.app_id).await?;
+                let var_names = get_variables(&client, app_id).await?;
                 for v in var_names {
                     println!("{}", v.key);
                 }
@@ -116,6 +93,17 @@ impl VariablesCommand {
         }
         Ok(())
     }
+}
+
+async fn client_and_app_id(
+    deployment_env_id: Option<&str>,
+    app: &str,
+) -> Result<(CloudClient, Uuid)> {
+    let client = create_cloud_client(deployment_env_id).await?;
+    let app_id = get_app_id_cloud(&client, app)
+        .await
+        .with_context(|| format!("Could not find app_id for app {}", app))?;
+    Ok((client, app_id))
 }
 
 pub(crate) async fn set_variables(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod opts;
 use anyhow::{anyhow, Error, Result};
 use clap::{FromArgMatches, Parser};
 use commands::{
-    deploy::DeployCommand, login::LoginCommand, sql::SqlCommand, variables::VariablesCommand,
+    deploy::DeployCommand, login::LoginCommand, sqlite::SqliteCommand, variables::VariablesCommand,
 };
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
@@ -31,9 +31,9 @@ enum CloudCli {
     /// Manage Spin application variables
     #[clap(subcommand, alias = "vars")]
     Variables(VariablesCommand),
-    /// Manage Fermyon Cloud SQL databases
-    #[clap(subcommand, alias = "sql")]
-    Sql(SqlCommand),
+    /// Manage Fermyon Cloud SQLite databases
+    #[clap(subcommand)]
+    Sqlite(SqliteCommand),
 }
 
 #[tokio::main]
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Error> {
         CloudCli::Deploy(cmd) => cmd.run().await,
         CloudCli::Login(cmd) => cmd.run().await,
         CloudCli::Variables(cmd) => cmd.run().await,
-        CloudCli::Sql(cmd) => cmd.run().await,
+        CloudCli::Sqlite(cmd) => cmd.run().await,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 mod commands;
 mod opts;
+
 use anyhow::{anyhow, Error, Result};
 use clap::{FromArgMatches, Parser};
-use commands::{deploy::DeployCommand, login::LoginCommand, variables::VariablesCommand};
+use commands::{
+    deploy::DeployCommand, login::LoginCommand, sql::SqlCommand, variables::VariablesCommand,
+};
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
 use std::path::Path;
@@ -28,6 +31,9 @@ enum CloudCli {
     /// Manage Spin application variables
     #[clap(subcommand, alias = "vars")]
     Variables(VariablesCommand),
+    /// Manage Fermyon Cloud SQL databases
+    #[clap(subcommand, alias = "sql")]
+    Sql(SqlCommand),
 }
 
 #[tokio::main]
@@ -42,6 +48,7 @@ async fn main() -> Result<(), Error> {
         CloudCli::Deploy(cmd) => cmd.run().await,
         CloudCli::Login(cmd) => cmd.run().await,
         CloudCli::Variables(cmd) => cmd.run().await,
+        CloudCli::Sql(cmd) => cmd.run().await,
     }
 }
 


### PR DESCRIPTION
Looks at an apps' requested `sqlite_databases` and creates a default database for the app if one does not exist.
Also contains other `sqlite` subcommands for listing and deleting databases

Depends on https://github.com/fermyon/cloud-openapi/pull/3