### PR TITLE
Add a header to the databases list output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "spin-loader",
  "spin-manifest",
  "tempfile",
+ "terminal",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 sha2 = "0.10.2"
+terminal = { git = "https://github.com/fermyon/spin", rev = "38e162b493316e744d4974675065dd9de20b3505" }
 spin-bindle = { git = "https://github.com/fermyon/spin", rev = "38e162b493316e744d4974675065dd9de20b3505" }
 spin-common = { git = "https://github.com/fermyon/spin", rev = "38e162b493316e744d4974675065dd9de20b3505" }
 spin-loader = { git = "https://github.com/fermyon/spin", rev = "38e162b493316e744d4974675065dd9de20b3505" }

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -75,6 +75,7 @@ impl SqliteCommand {
 }
 
 fn print_databases(databases: Vec<Database>) {
+    terminal::step!("Databases", "({})", databases.len());
     for d in databases {
         let default_str = if d.default { " (default)" } else { "" };
         println!("{}{default_str}", d.name);

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -75,6 +75,10 @@ impl SqliteCommand {
 }
 
 fn print_databases(databases: Vec<Database>) {
+    if databases.is_empty() {
+        println!("No databases");
+        return;
+    }
     terminal::step!("Databases", "({})", databases.len());
     for d in databases {
         let default_str = if d.default { " (default)" } else { "" };


### PR DESCRIPTION
This adds a header to the list of running `cloud-plugin sqlite list`. This is particularly helpful when there are no databases as it otherwise just prints nothing.

<img width="315" alt="image" src="https://github.com/fermyon/cloud-plugin/assets/1327285/79cd10fc-186a-4f1e-8536-7b2019096f4a">
