### PR TITLE
sqlite delete: remove extra punctuation

### DIFF
--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -89,7 +89,7 @@ fn print_databases(databases: Vec<Database>) {
 fn prompt_delete_database(database_name: &str) -> std::io::Result<bool> {
     let mut input = Input::<String>::new();
     let prompt =
-        format!("The action is irreversible. Please type \"{database_name}\" for confirmation.",);
+        format!("The action is irreversible. Please type \"{database_name}\" for confirmation",);
     input.with_prompt(prompt);
     let answer = input.interact_text()?;
     if answer != database_name {


### PR DESCRIPTION
When deleting a sqlite database the prompt currently looks like:

[spin(HEAD)] $ spin cloud sqlite delete nonsense
The action is irreversible. Please type "nonsense" for confirmation.: {cursor here}

The full-stop followed by the colon is a little weird, so drop the full-stop from the prompt to get:

[spin(HEAD)] $ spin cloud sqlite delete nonsense
The action is irreversible. Please type "nonsense" for confirmation: {cursor here}