### PR TITLE
Overwrite the canary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: _dist/cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          overwrite: true
           tag: "canary"
 
   checksums_and_manifests:
@@ -208,6 +209,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: checksums-${{ env.RELEASE_VERSION }}.txt
+          overwrite: true
           tag: "canary"
 
       - name: create plugin manifest


### PR DESCRIPTION
Currently uploading the canary release fails because it already exists. This overwrites the previous canary release.