### PR TITLE
ci(*): add makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,8 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Cargo Format
-        run:
-          cargo fmt --all -- --check
-
-      - name: Cargo Clippy
-        run:
-          cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Lint
+        run: make lint
 
   build-rust:
     name: Build Cloud Plugin
@@ -76,8 +71,8 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Cargo Build
-        run: cargo build --workspace --release --all-targets --all-features
+      - name: Build
+        run: make build
         env:
           CARGO_INCREMENTAL: 0
 
@@ -106,9 +101,8 @@ jobs:
 
       - uses: actions/checkout@v3
       
-      - name: Cargo Unit Tests
-        run: |
-          cargo test --all --no-fail-fast -- --nocapture
+      - name: Run Tests
+        run: make test
         env:
           CARGO_INCREMENTAL: 0
           RUST_LOG: trace

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+cloud.json
+cloud.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ package:
 
 .PHONY: install
 install: package
+ifeq (, $(shell which jq))
+	$(error "jq not found in PATH. Please add it or install the plugin manually")
+endif
+ifeq (, $(shell which spin))
+	$(error "spin not found in PATH. It is required for installing this plugin")
+endif
+
 	@curl -sLR -o /tmp/cloud.json https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json
 	@jq -j \
 		--arg os $(OS_TYPE) \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+OS_TYPE ?= 
+ARCH ?=
+ifeq ($(OS),Windows_NT)
+	OS_TYPE = windows
+	ARCH = amd64
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OS_TYPE = linux
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OS_TYPE = macos
+	endif
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),x86_64)
+		ARCH = amd64
+	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		ARCH = aarch64
+	endif
+endif
+
+.PHONY: build
+build:
+	cargo build --workspace --release --all-targets --all-features
+
+.PHONY: test
+test:
+	cargo test --all --no-fail-fast -- --nocapture
+
+.PHONY: lint
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo fmt --all -- --check
+
+.PHONY: package
+package:
+	@cp target/release/cloud-plugin cloud
+	@tar -czvf cloud.tar.gz cloud &>/dev/null
+	@sha256sum cloud.tar.gz | cut -c -64 | tr -d '\n' > /tmp/cloud.sha256sum
+	@rm cloud
+
+.PHONY: install
+install: package
+	@curl -sLR -o /tmp/cloud.json https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json
+	@jq -j \
+		--arg os $(OS_TYPE) \
+		--arg arch $(ARCH) \
+		--arg sha256sum "$$(</tmp/cloud.sha256sum)" \
+		--arg url "file://$$(pwd)/cloud.tar.gz" \
+		'(.packages[] | select(.os==$$os and .arch==$$arch) ).sha256 = $$sha256sum | (.packages[] | select(.os==$$os and .arch==$$arch) ).url = $$url' \
+		/tmp/cloud.json > cloud.json
+	spin plugin install -y -f ./cloud.json

--- a/README.md
+++ b/README.md
@@ -10,16 +10,41 @@ spin plugin install --url https://github.com/fermyon/cloud-plugin/releases/downl
 
 ## Building and installing local changes
 
-1. Package the plugin.
+1. Build the plugin.
 
     ```sh
-    cargo build --release
-    cp target/release/cloud-plugin cloud
-    tar -czvf cloud.tar.gz cloud
-    sha256sum cloud.tar.gz
-    rm cloud
-    # Outputs a shasum to add to cloud.json
+    make build
     ```
+
+1. Install the plugin.
+
+    ```sh
+    make install
+    ```
+
+1. Run the plugin.
+
+    ```sh
+    spin cloud --help
+    ```
+
+## Run tests
+
+1. Lint/format code.
+
+    ```sh
+    make lint
+    ```
+
+1. Run tests.
+
+    ```sh
+    make test
+    ```
+
+## Installing local changes by hand
+
+In case `make install` doesn't work or you prefer to install manually.
 
 1. Get the manifest.
 
@@ -27,16 +52,10 @@ spin plugin install --url https://github.com/fermyon/cloud-plugin/releases/downl
     curl -LRO https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json
     ```
 
-1. Update the manifest to modify the `url` field to point to the path to local package (i.e. `"url": "file:///path/to/cloud-plugin/plugin/cloud.tar.gz"`) and update the shasum.
+1. Update the manifest to modify the `url` field to point to the path to local package (i.e. `"url": "file:///path/to/cloud-plugin/cloud.tar.gz"`) and update the shasum.
 
 1. Install the plugin, pointing to the path to the manifest.
 
     ```sh
-    spin plugin install -f ./plugin/cloud.json
-    ```
-
-1. Run the plugin.
-
-    ```sh
-    spin cloud --help
+    spin plugin install -f ./cloud.json
     ```


### PR DESCRIPTION
This is a little bit of a smorgasbord of CI additions and am open to scoping to just the ones desired.  My primary motivation was to reduce the build->package->install cycle during development, hence the Makefile and associated targets, doing away with the need to manually edit cloud.json and install, etc.  I figured while doing so, I would add lint and test targets and use these in CI so that devs and automation are invoking the same commands.