### PR TITLE
ci(release.yml): ensure workflow runs sequentially

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
       - "supply-chain/**"
   workflow_dispatch:
 
+# Construct a concurrency group to be shared across workflow runs.
+# The default behavior ensures that only one is running at a time, with
+# all others queuing and thus not interrupting runs that are in-flight.
+concurrency: ${{ github.workflow }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
@karthik2804 mentioned that the release workflow may fail if more than one runs at a time, due to the `canary` GH release deletion/recreation.  This PR prevents concurrent runs.

May fix or help https://github.com/fermyon/cloud-plugin/issues/39