### PR TITLE
ci(.github): address deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.68
 jobs:
   lint-rust:
     name: Lint Rust
@@ -30,11 +31,10 @@ jobs:
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: '1.68'
-          default: true
-          components: clippy, rustfmt
+        shell: bash
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt
+          rustup default ${{ env.RUST_VERSION }}
       - name: "Install Wasm Rust target"
         run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
         shell: bash
@@ -62,11 +62,10 @@ jobs:
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: '1.68'
-          default: true
-          components: clippy, rustfmt
+        shell: bash
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt
+          rustup default ${{ env.RUST_VERSION }}
       - name: "Install Wasm Rust target"
         run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
         shell: bash
@@ -89,14 +88,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-
       # install dependencies
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: '1.68'
-          default: true
-          components: clippy, rustfmt
+        shell: bash
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt
+          rustup default ${{ env.RUST_VERSION }}
       - name: "Install Wasm Rust target"
         run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ concurrency: ${{ github.workflow }}
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.68
 
 jobs:
   reset_canary_release: 
@@ -31,7 +32,10 @@ jobs:
       - name: 'Check if canary tag exists'
         id: canaryExists
         shell: bash
-        run: git show-ref --tags --verify --quiet -- "refs/tags/canary" && echo "::set-output name=canaryExists::0" || echo "::set-output name=canaryExists::1"
+        run: |
+          git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
+          echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
+          echo "canaryExists=1" >> "$GITHUB_OUTPUT"
 
       - name: Delete canary tag
         if: steps.canaryExists.outputs.canaryExists == 0
@@ -42,7 +46,7 @@ jobs:
           tag_name: canary
 
       - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@v1.12.0
         with:
           tag: canary
           allowUpdates: true
@@ -106,12 +110,16 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.68
-          default: true
-          target: ${{ matrix.config.target }}
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }}
+          rustup default ${{ env.RUST_VERSION }}
+
+      - name: Install target
+        if: matrix.config.target != ''
+        shell: bash
+        run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
         run: rustup target add wasm32-wasi --toolchain 1.68 && rustup target add wasm32-unknown-unknown --toolchain 1.68
@@ -140,10 +148,8 @@ jobs:
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
 
       - name: build release
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: "--release ${{ matrix.config.buildArgs }}"
+        shell: bash
+        run: cargo build --release ${{ matrix.config.buildArgs }}
 
       - name: Package as plugins tar
         shell: bash


### PR DESCRIPTION
  - remove use of actions-rs actions (see also https://github.com/fermyon/spin/pull/1697)
  - bump ncipollo/release-action
  - use GITHUB_OUTPUT env for outputs

Closes https://github.com/fermyon/cloud-plugin/issues/61