### PR TITLE
ci(release.yml): fetch tags to fix canaryExists logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         id: canaryExists
         shell: bash
         run: |
+          git fetch --prune --unshallow --tags
           git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
           echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
           echo "canaryExists=1" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Previously, tags weren't actually fetched, throwing off the `canaryExists` logic.

Interestingly, tags still won't be fetched when `fetch-depth` is > 0 (as is the default, being 1), even when toggling `fetch-tags: true` on the [checkout](https://github.com/actions/checkout) action.  (See https://github.com/actions/checkout/issues/701).

Therefore, I just add a `git fetch --prune --unshallow --tags` to start the step.  (Prefer not to set `fetch-depth` to 0 and thus fetch all git history.)

~Depends on https://github.com/fermyon/cloud-plugin/pull/64 (will convert from Draft once merged)~