### PR TITLE
add apps subcommand that allows to list and delete apps

### DIFF
--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -155,10 +155,18 @@ impl Client {
             .map_err(format_response_error)
     }
 
-    pub async fn list_apps(&self) -> Result<AppItemPage> {
-        api_apps_get(&self.configuration, None, None, None, None, None, None)
-            .await
-            .map_err(format_response_error)
+    pub async fn list_apps(&self, page_size: i32, page_index: Option<i32>) -> Result<AppItemPage> {
+        api_apps_get(
+            &self.configuration,
+            None,
+            page_index,
+            Some(page_size),
+            None,
+            None,
+            None,
+        )
+        .await
+        .map_err(format_response_error)
     }
 
     pub async fn get_channel_by_id(&self, id: &str) -> Result<ChannelItem> {

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -1,0 +1,80 @@
+use crate::commands::{client_and_app_id, create_cloud_client};
+use crate::opts::*;
+use anyhow::{Context, Result};
+use clap::{Args, Parser};
+use cloud_openapi::models::AppItemPage;
+
+#[derive(Parser, Debug)]
+#[clap(about = "Manage applications deployed to Fermyon Cloud")]
+pub enum AppsCommand {
+    /// List all the apps deployed in Fermyon Cloud
+    List(ListCommand),
+    /// Delete an app deployed in Fermyon Cloud
+    Delete(DeleteCommand),
+}
+
+#[derive(Parser, Debug)]
+pub struct ListCommand {
+    #[clap(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct DeleteCommand {
+    /// Name of Spin app
+    pub app: String,
+    #[clap(flatten)]
+    common: CommonArgs,
+}
+
+#[derive(Debug, Default, Args)]
+struct CommonArgs {
+    /// Deploy to the Fermyon instance saved under the specified name.
+    /// If omitted, Spin deploys to the default unnamed instance.
+    #[clap(
+        name = "environment-name",
+        long = "environment-name",
+        env = DEPLOYMENT_ENV_NAME_ENV
+    )]
+    pub deployment_env_id: Option<String>,
+}
+
+impl AppsCommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            AppsCommand::List(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                let mut app_list_page = client.list_apps(DEFAULT_APPLIST_PAGE_SIZE, None).await?;
+                if app_list_page.total_items > 0 {
+                    eprintln!("No applications found");
+                } else {
+                    print_app_list(&app_list_page);
+                    let mut page_index = 1;
+                    while !app_list_page.is_last_page {
+                        app_list_page = client
+                            .list_apps(DEFAULT_APPLIST_PAGE_SIZE, Some(page_index))
+                            .await?;
+                        print_app_list(&app_list_page);
+                        page_index += 1;
+                    }
+                }
+            }
+            AppsCommand::Delete(cmd) => {
+                let (client, app_id) =
+                    client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.app).await?;
+                client
+                    .remove_app(app_id.to_string())
+                    .await
+                    .with_context(|| format!("Problem deleting app named {}", &cmd.app))?;
+                println!("Deleted app \"{}\" successfully.", &cmd.app);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_app_list(page: &AppItemPage) {
+    for app in &page.items {
+        println!("{}", app.name);
+    }
+}

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -404,7 +404,7 @@ impl DeployCommand {
         cloud_client: &CloudClient,
         name: String,
     ) -> Result<Option<Uuid>> {
-        let apps_vm = CloudClient::list_apps(cloud_client).await?;
+        let apps_vm = CloudClient::list_apps(cloud_client, DEFAULT_APPLIST_PAGE_SIZE, None).await?;
         let app = apps_vm.items.iter().find(|&x| x.name == name.clone());
         match app {
             Some(a) => Ok(Some(a.id)),

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -230,7 +230,8 @@ impl LoginCommand {
             insecure: self.insecure,
             token: token.clone(),
         })
-        .list_apps()
+        // Just getting the first app as we just use it to test credentials
+        .list_apps(1, None)
         .await
         .context("Login using the provided personal access token failed. Run `spin login` or create a new token using the Fermyon Cloud user interface.")?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,10 +1,11 @@
+pub mod apps;
 pub mod deploy;
 pub mod login;
 pub mod sqlite;
 pub mod variables;
 
-use crate::commands::deploy::login_connection;
-use anyhow::{bail, Result};
+use crate::{commands::deploy::login_connection, opts::DEFAULT_APPLIST_PAGE_SIZE};
+use anyhow::{bail, Context, Result};
 use cloud::client::{Client as CloudClient, ConnectionConfig};
 use uuid::Uuid;
 
@@ -19,10 +20,21 @@ pub(crate) async fn create_cloud_client(deployment_env_id: Option<&str>) -> Resu
 }
 
 pub(crate) async fn get_app_id_cloud(cloud_client: &CloudClient, name: &str) -> Result<Uuid> {
-    let apps_vm = CloudClient::list_apps(cloud_client).await?;
+    let apps_vm = CloudClient::list_apps(cloud_client, DEFAULT_APPLIST_PAGE_SIZE, None).await?;
     let app = apps_vm.items.iter().find(|&x| x.name == name);
     match app {
         Some(a) => Ok(a.id),
         None => bail!("No app with name: {}", name),
     }
+}
+
+async fn client_and_app_id(
+    deployment_env_id: Option<&str>,
+    app: &str,
+) -> Result<(CloudClient, Uuid)> {
+    let client = create_cloud_client(deployment_env_id).await?;
+    let app_id = get_app_id_cloud(&client, app)
+        .await
+        .with_context(|| format!("Could not find app_id for app {}", app))?;
+    Ok((client, app_id))
 }

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -6,9 +6,8 @@ use serde_json::from_str;
 use spin_common::arg_parser::parse_kv;
 use uuid::Uuid;
 
+use crate::commands::client_and_app_id;
 use crate::opts::*;
-
-use crate::commands::{create_cloud_client, get_app_id_cloud};
 
 #[derive(Deserialize)]
 pub(crate) struct Variable {
@@ -93,17 +92,6 @@ impl VariablesCommand {
         }
         Ok(())
     }
-}
-
-async fn client_and_app_id(
-    deployment_env_id: Option<&str>,
-    app: &str,
-) -> Result<(CloudClient, Uuid)> {
-    let client = create_cloud_client(deployment_env_id).await?;
-    let app_id = get_app_id_cloud(&client, app)
-        .await
-        .with_context(|| format!("Could not find app_id for app {}", app))?;
-    Ok((client, app_id))
 }
 
 pub(crate) async fn set_variables(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ mod opts;
 use anyhow::{anyhow, Error, Result};
 use clap::{FromArgMatches, Parser};
 use commands::{
-    deploy::DeployCommand, login::LoginCommand, sqlite::SqliteCommand, variables::VariablesCommand,
+    apps::AppsCommand, deploy::DeployCommand, login::LoginCommand, sqlite::SqliteCommand,
+    variables::VariablesCommand,
 };
 use semver::BuildMetadata;
 use spin_bindle::PublishError;
@@ -24,6 +25,9 @@ const VERSION: &str = concat!(
 #[clap(author, version = VERSION, about, long_about = None)]
 #[clap(propagate_version = true)]
 enum CloudCli {
+    /// Manage applications deployed to Fermyon Cloud
+    #[clap(subcommand)]
+    Apps(AppsCommand),
     /// Package and upload an application to the Fermyon Cloud.
     Deploy(DeployCommand),
     /// Login to Fermyon Cloud
@@ -45,6 +49,7 @@ async fn main() -> Result<(), Error> {
     let cli = CloudCli::from_arg_matches(&matches)?;
 
     match cli {
+        CloudCli::Apps(cmd) => cmd.run().await,
         CloudCli::Deploy(cmd) => cmd.run().await,
         CloudCli::Login(cmd) => cmd.run().await,
         CloudCli::Variables(cmd) => cmd.run().await,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -8,3 +8,4 @@ pub const CLOUD_URL_ENV: &str = "CLOUD_URL";
 pub const DEPLOYMENT_ENV_NAME_ENV: &str = "FERMYON_DEPLOYMENT_ENVIRONMENT";
 pub const TOKEN: &str = "TOKEN";
 pub const SPIN_AUTH_TOKEN: &str = "SPIN_AUTH_TOKEN";
+pub const DEFAULT_APPLIST_PAGE_SIZE: i32 = 50;


### PR DESCRIPTION
This PR adds a new top-level command `apps` that further has `list` and `delete` subcommands. 

fixes #9
fixes #40 