### PR TITLE
fix(build.rs): don't fail on error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,6 @@ fn main() {
     vergen::EmitBuilder::builder()
         .git_commit_date()
         .git_sha(true)
-        .fail_on_error()
         .emit()
         .expect("failed to extract build information");
 }


### PR DESCRIPTION
I'm unable to build this plugin when `fail_on_error()` is set in the build script, due to [vergen](https://docs.rs/vergen/latest/vergen/) claiming that I am not in a valid git worktree:

```
$ cargo build --release
...
error: failed to run custom build command for `cloud-plugin v0.1.2 (/Users/vdice/go/src/github.com/fermyon/cloud-plugin)`

Caused by:
  process didn't exit successfully: `/Users/vdice/go/src/github.com/fermyon/cloud-plugin/target/release/build/cloud-plugin-56e76e8961f4ea6a/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'failed to extract build information: not within a suitable 'git' worktree!', build.rs:7:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

I noticed we've also removed the `fail_on_error()` toggle in Spin (https://github.com/fermyon/spin/pull/1590), so I propose we do the same here.