### PR TITLE
chore(*): bump plugin version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bindle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "cloud"
 description = "Commands for publishing applications to the Fermyon Cloud."
-version = "0.1.2"
+version = "0.2.0"
 spin_compatibility = ">=1.3"
 license = "Apache-2.0"
 homepage = "https://github.com/fermyon/cloud-plugin"


### PR DESCRIPTION
Bumps this plugin version to 0.2.0 in anticipation of a release of the same version.