### PR TITLE
Add app name to AppLabel

### DIFF
--- a/crates/cloud/src/mocks.rs
+++ b/crates/cloud/src/mocks.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 pub struct AppLabel {
     pub label: String,
     pub app_id: Uuid,
+    pub app_name: String,
 }
 
 #[derive(Clone, PartialEq)]
@@ -45,7 +46,12 @@ impl Database {
 impl AppLabel {
     pub fn new(label: String) -> Self {
         let app_id = Uuid::new_v4();
-        AppLabel { label, app_id }
+        let app_name = format!("myapp-{}", app_id.as_simple());
+        AppLabel {
+            label,
+            app_id,
+            app_name,
+        }
     }
 }
 

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -190,7 +190,11 @@ impl DeployCommand {
         let channel_id = match get_app_id_cloud(&client, &name).await? {
             Some(app_id) => {
                 for label in databases_used(&cfg) {
-                    let link = AppLabel { app_id, label };
+                    let link = AppLabel {
+                        app_id,
+                        label,
+                        app_name: name.clone(),
+                    };
                     if let DatabaseForExistingApp::UserSelection(selection) =
                         get_database_selection_for_existing_app(&name, &client, &link).await?
                     {
@@ -274,7 +278,11 @@ impl DeployCommand {
                     .context("Unable to create app")?;
 
                 for (database_to_link, label) in databases_to_link {
-                    let link = AppLabel { label, app_id };
+                    let link = AppLabel {
+                        label,
+                        app_id,
+                        app_name: name.clone(),
+                    };
                     CloudClient::create_link(&client, &link, &database_to_link)
                         .await
                         .with_context(|| {
@@ -609,7 +617,8 @@ enum DatabaseSelection {
     Cancelled,
 }
 
-/// A user's selection of a database to link to a
+/// A enum of a database to link to a label or indication that the link is
+/// already resolved
 enum DatabaseForExistingApp {
     UserSelection(DatabaseSelection),
     AlreadyLinked,

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -63,20 +63,21 @@ impl SqliteLinkCommand {
         let link = AppLabel {
             app_id,
             label: self.label,
+            app_name: self.app,
         };
         match (existing_link_for_database, existing_link_with_name) {
             (Some(link), _) => {
                 anyhow::bail!(
                     r#"Database "{}" is already linked to app "{}" with label "{}""#,
                     link.database,
-                    self.app,
+                    link.app_label.app_name,
                     link.app_label.label,
                 );
             }
             (_, Some(link)) => {
                 anyhow::bail!(
                     r#"A Database is already linked to app "{}" with the label "{}""#,
-                    self.app,
+                    link.app_label.app_name,
                     link.app_label.label,
                 );
             }

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -163,7 +163,7 @@ fn print_databases(
         })
         .collect();
     if let Some(name) = &app {
-        links.retain(|d| d.link.app_id.to_string() == *name);
+        links.retain(|d| d.link.app_name == *name);
     }
 
     let mut table = comfy_table::Table::new();
@@ -177,8 +177,8 @@ fn print_databases(
         let mut map = HashMap::new();
         links.into_iter().for_each(|d| {
             map.entry(d.name)
-                .and_modify(|v| *v = format!("{}, {}:{}", *v, d.link.app_id, d.link.label))
-                .or_insert(format!("{}:{}", d.link.app_id, d.link.label));
+                .and_modify(|v| *v = format!("{}, {}:{}", *v, d.link.app_name, d.link.label))
+                .or_insert(format!("{}:{}", d.link.app_name, d.link.label));
         });
         map.into_iter().for_each(|e| {
             table.add_row(vec![e.0, e.1]);
@@ -187,7 +187,7 @@ fn print_databases(
         links.into_iter().for_each(|d| {
             table.add_row(vec![
                 d.name.clone(),
-                format!("{}:{}", d.link.app_id, d.link.label),
+                format!("{}:{}", d.link.app_name, d.link.label),
             ]);
         });
     }
@@ -197,7 +197,7 @@ fn print_databases(
 fn prompt_delete_database(database: &str, links: &[AppLabel]) -> std::io::Result<bool> {
     let existing_links = links
         .iter()
-        .map(|l| format!("{}:{}", l.app_id, l.label))
+        .map(|l| format!("{}:{}", l.app_name, l.label))
         .collect::<Vec<String>>()
         .join(", ");
     let mut prompt = String::new();


### PR DESCRIPTION
Users expect to interact with app name rather than app ID. In order to output app names for `spin cloud sqlite list` commands, we should add app name to the `AppLabel` struct.