### PR TITLE
ci(release.yml): only recreate canary once all artifacts are ready to upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,43 +23,9 @@ env:
   RUST_VERSION: 1.68
 
 jobs:
-  reset_canary_release: 
-    name: Delete and create Canary Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: 'Check if canary tag exists'
-        id: canaryExists
-        shell: bash
-        run: |
-          git fetch --prune --unshallow --tags
-          git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
-          echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
-          echo "canaryExists=1" >> "$GITHUB_OUTPUT"
-
-      - name: Delete canary tag
-        if: steps.canaryExists.outputs.canaryExists == 0
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: canary
-
-      - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          tag: canary
-          allowUpdates: true
-          prerelease: true
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features in cloud plugin, some of which may not be fully implemented.
-
   build:
     name: Build cloud plugin
     runs-on: ${{ matrix.config.os }}
-    needs: reset_canary_release
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +105,7 @@ jobs:
         run: |
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=$OS" >> $GITHUB_ENV
-      
+
       - name: setup for cross-compiled linux aarch64 build
         if: matrix.config.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -158,15 +124,15 @@ jobs:
           mkdir -v _dist
           cp ${{ matrix.config.targetDir }}/cloud-plugin${{ matrix.config.extension }} _dist/cloud${{ matrix.config.extension }}
           cp  LICENSE _dist/cloud.license
-          cd _dist 
+          cd _dist
           tar czf cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz cloud.license cloud${{ matrix.config.extension }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-            name: cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+            name: cloud
             path: _dist/cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-            
+
       - name: upload binary to Github release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2
@@ -175,21 +141,13 @@ jobs:
           file: _dist/cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           tag: ${{ github.ref }}
 
-      - name: upload binary to Github release (canary)
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          overwrite: true
-          tag: "canary"
-
   checksums_and_manifests:
     name: generate checksums and manifest
     runs-on: ubuntu-latest
     needs: build
     steps:
-
       - uses: actions/checkout@v3
+
       - name: set the release version (main)
         shell: bash
         run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
@@ -201,11 +159,18 @@ jobs:
 
       - name: download release assets
         uses: actions/download-artifact@v3
+        with:
+          name: cloud
 
       - name: generate checksums
         run: |
           ls -lh
-          sha256sum cloud*.tar.gz/cloud*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+          sha256sum cloud*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cloud
+          path: checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: upload checksums to Github release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -215,25 +180,62 @@ jobs:
           file: checksums-${{ env.RELEASE_VERSION }}.txt
           tag: ${{ github.ref }}
 
-      - name: upload checksums to Github release (canary)
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: checksums-${{ env.RELEASE_VERSION }}.txt
-          overwrite: true
-          tag: "canary"
-
       - name: create plugin manifest
         shell: bash
-        env:
-          REPO_OWNER: ${{ github.repository_owner }}
         run: bash .plugin-manifests/generate-manifest.sh ${{ env.RELEASE_VERSION }} checksums-${{ env.RELEASE_VERSION }}.txt > cloud.json
 
-      - name: upload plugin manifest to releases
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cloud
+          path: cloud.json
+
+      - name: upload plugin manifest to release
         uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: cloud.json
-          overwrite: true
-          tag: ${{ env.RELEASE_VERSION }}
+          tag: ${{ github.ref }}
+
+  reset_canary_release:
+    name: Delete and create Canary Release
+    runs-on: ubuntu-latest
+    needs: checksums_and_manifests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: cloud
+
+      - name: 'Check if canary tag exists'
+        id: canaryExists
+        shell: bash
+        run: |
+          git fetch --prune --unshallow --tags
+          git show-ref --tags --verify --quiet -- "refs/tags/canary" && \
+          echo "canaryExists=0" >> "$GITHUB_OUTPUT" || \
+          echo "canaryExists=1" >> "$GITHUB_OUTPUT"
+
+      - name: Delete canary tag
+        if: steps.canaryExists.outputs.canaryExists == 0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: canary
+          delete_release: true
+
+      - name: Recreate canary tag and release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          tag: canary
+          allowUpdates: true
+          prerelease: true
+          artifacts: "cloud*.tar.gz,cloud.json,checksums-canary.txt"
+          commit: ${{ github.sha }}
+          body: |
+            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
+            It is only intended for developers wishing to try out the latest features in cloud plugin, some of which may not be fully implemented.


### PR DESCRIPTION
Closes https://github.com/fermyon/cloud-plugin/issues/84

Run on fork: https://github.com/vdice/cloud-plugin/actions/runs/6190247031