### PR TITLE
ci(release): pin ubuntu runners to 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-latest",
+              os: "ubuntu-20.04",
               arch: "amd64",
               wasiSDK: "linux",
               extension: "",
@@ -40,7 +40,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-            os: "ubuntu-latest",
+            os: "ubuntu-20.04",
             arch: "aarch64",
             wasiSDK: "linux",
             extension: "",


### PR DESCRIPTION
Pins CI runner version so as to produce compatible builds. 
