### PR TITLE
Do not offer --version on subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ const VERSION: &str = concat!(
 
 #[derive(Parser)]
 #[clap(author, version = VERSION, about, long_about = None)]
-#[clap(propagate_version = true)]
 enum CloudCli {
     /// Manage applications deployed to Fermyon Cloud
     #[clap(subcommand)]


### PR DESCRIPTION
Fixes #83.

As noted on that issue, before merging this we should understand the intent behind having the `propagate_version` flag there in the first place.  @kate-goldenring `git blame` has your name on the commit, though I think several people contributed to that first cut - do you know why this was set?

Before:

```
$ spin cloud variables -V
spin-cloud-variables 0.2.0 (78c325a 2023-09-14)
```

After:

```
$ spin cloud variables -V
error: Found argument '-V' which wasn't expected, or isn't valid in this context

        If you tried to supply `-V` as a value rather than a flag, use `-- -V`

USAGE:
    spin cloud variables <SUBCOMMAND>

For more information try --help

# Still works on top-level command
$ spin cloud -V
spin-cloud 0.2.0 (78c325a 2023-09-14)
```
