### PR TITLE
ci(release.yml): add REPO_OWNER when generating plugin manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,8 @@ jobs:
 
       - name: create plugin manifest
         shell: bash
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
         run: bash .plugin-manifests/generate-manifest.sh ${{ env.RELEASE_VERSION }} checksums-${{ env.RELEASE_VERSION }}.txt > cloud.json
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This was originally added in https://github.com/fermyon/cloud-plugin/pull/7 but inadvertently removed in https://github.com/fermyon/cloud-plugin/pull/85 😅 .  Adding it back in.