### PR TITLE
ci(.github): bump rust to 1.71; add +fp16 rustc flag for linux/aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.68
+  RUST_VERSION: 1.71
 jobs:
   lint-rust:
     name: Lint Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency: ${{ github.workflow }}
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.68
+  RUST_VERSION: 1.71
 
 jobs:
   build:
@@ -89,7 +89,7 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain 1.68 && rustup target add wasm32-unknown-unknown --toolchain 1.68
+        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: set the release version (main)
         shell: bash
@@ -113,6 +113,7 @@ jobs:
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
+          echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> ${HOME}/.cargo/config.toml
 
       - name: build release
         shell: bash


### PR DESCRIPTION
CI updates to mirror what was bumped in Spin in the v1.4.2->v1.5.0 timeframe (eg https://github.com/fermyon/spin/pull/1731 and https://github.com/fermyon/spin/pull/1741)

Prerequisite PR in anticipation of revving the spin crates to v1.5.0 in https://github.com/fermyon/cloud-plugin/pull/57