### PR TITLE
Add get app subcommand to get app details

### DIFF
--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use cloud_openapi::{
     apis::{
         self,
-        apps_api::{api_apps_get, api_apps_id_delete, api_apps_post},
+        apps_api::{api_apps_get, api_apps_id_delete, api_apps_id_get, api_apps_post},
         auth_tokens_api::api_auth_tokens_refresh_post,
         channels_api::{
             api_channels_get, api_channels_id_delete, api_channels_id_get,
@@ -22,7 +22,7 @@ use cloud_openapi::{
         Error, ResponseContent,
     },
     models::{
-        AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy,
+        AppItem, AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy,
         CreateAppCommand, CreateChannelCommand, CreateDeviceCodeCommand, CreateKeyValuePairCommand,
         CreateSqlDatabaseCommand, CreateVariablePairCommand, Database, DeleteSqlDatabaseCommand,
         DeleteVariablePairCommand, DeviceCodeItem, EnvironmentVariableItem,
@@ -152,6 +152,12 @@ impl Client {
 
     pub async fn remove_app(&self, id: String) -> Result<()> {
         api_apps_id_delete(&self.configuration, &id, None)
+            .await
+            .map_err(format_response_error)
+    }
+
+    pub async fn get_app(&self, id: String) -> Result<AppItem> {
+        api_apps_id_get(&self.configuration, &id, None)
             .await
             .map_err(format_response_error)
     }

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -11,8 +11,8 @@ pub enum AppsCommand {
     List(ListCommand),
     /// Delete an app deployed in Fermyon Cloud
     Delete(DeleteCommand),
-    /// Get Details about a deployed app in Fermyon Cloud
-    Get(GetCommand),
+    /// Get details about a deployed app in Fermyon Cloud
+    Info(InfoCommand),
 }
 
 #[derive(Parser, Debug)]
@@ -30,7 +30,7 @@ pub struct DeleteCommand {
 }
 
 #[derive(Parser, Debug)]
-pub struct GetCommand {
+pub struct InfoCommand {
     /// Name of Spin app
     pub app: String,
     #[clap(flatten)]
@@ -78,7 +78,7 @@ impl AppsCommand {
                     .with_context(|| format!("Problem deleting app named {}", &cmd.app))?;
                 println!("Deleted app \"{}\" successfully.", &cmd.app);
             }
-            AppsCommand::Get(cmd) => {
+            AppsCommand::Info(cmd) => {
                 let (client, app_id) =
                     client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.app).await?;
                 let app = client


### PR DESCRIPTION
This PR adds a get subcommand to apps to allow for getting details about an app. It helps with getting the Base URL of apps quickly without having to open up the cloud UI.