### PR TITLE
Option to force build before deploy

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -30,9 +30,12 @@ use std::{
 use url::Url;
 use uuid::Uuid;
 
-use crate::commands::{
-    get_app_id_cloud,
-    variables::{get_variables, set_variables, Variable},
+use crate::{
+    commands::{
+        get_app_id_cloud,
+        variables::{get_variables, set_variables, Variable},
+    },
+    spin,
 };
 
 use crate::{
@@ -77,6 +80,10 @@ pub struct DeployCommand {
     )]
     pub buildinfo: Option<BuildMetadata>,
 
+    /// Specifies to perform `spin build` before deploying the application.
+    #[clap(long, takes_value = false, env = "SPIN_ALWAYS_BUILD")]
+    pub build: bool,
+
     /// How long in seconds to wait for a deployed HTTP application to become
     /// ready. The default is 60 seconds. Set it to 0 to skip waiting
     /// for readiness.
@@ -107,6 +114,10 @@ pub struct DeployCommand {
 
 impl DeployCommand {
     pub async fn run(self) -> Result<()> {
+        if self.build {
+            self.run_spin_build().await?;
+        }
+
         let login_connection = login_connection(self.deployment_env_id.as_deref()).await?;
 
         const DEVELOPER_CLOUD_FAQ: &str = "https://developer.fermyon.com/cloud/faq";
@@ -512,6 +523,24 @@ impl DeployCommand {
         let digest = client.push(&application, reference).await?;
 
         Ok(digest)
+    }
+
+    async fn run_spin_build(&self) -> Result<()> {
+        let manifest_path = self.app()?;
+        let spin_bin = spin::bin_path()?;
+
+        let result = tokio::process::Command::new(spin_bin)
+            .args(["build", "-f"])
+            .arg(&manifest_path)
+            .status()
+            .await
+            .context("Failed to execute `spin build` command")?;
+
+        if result.success() {
+            Ok(())
+        } else {
+            Err(anyhow!("Build failed: deployment cancelled"))
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod opts;
+mod spin;
 
 use anyhow::{Error, Result};
 use clap::{FromArgMatches, Parser};

--- a/src/spin.rs
+++ b/src/spin.rs
@@ -1,0 +1,6 @@
+use std::path::PathBuf;
+
+pub fn bin_path() -> anyhow::Result<PathBuf> {
+    let bin_path = std::env::var("SPIN_BIN_PATH")?;
+    Ok(PathBuf::from(bin_path))
+}


### PR DESCRIPTION
Fixes #95.

Happy path:

```
ivan@hecate:~/testing/hello3$ spin deploy --build
Building component hello3 with `cargo build --target wasm32-wasi --release`
   Compiling hello3 v0.1.0 (/home/ivan/testing/hello3)
    Finished release [optimized] target(s) in 1.19s
Finished building all Spin components
Uploading hello3 version 0.1.0+r73691dd...
Deploying...
Waiting for application to become ready.......... ready
Available Routes:
  hello3: https://hello3-prfvru2v.fermyon.app (wildcard)
```

Sad path:

```
ivan@hecate:~/testing/hello3$ spin deploy --build
Building component hello3 with `cargo build --target wasm32-wasi --release`
   Compiling hello3 v0.1.0 (/home/ivan/testing/hello3)
error[E0425]: cannot find function, tuple struct or tuple variant `Sum` in this scope
  --> src/lib.rs:12:15
   |
12 |         .body(Sum("Hello, Mistress Ploppy".into()))?)
   |               ^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `hello3` (lib) due to previous error
Error: Build command for component hello3 failed with status Exited(101)
Error: Build failed: deployment cancelled
```

I know that's a lot of errors at the end but that's fiddly to fix with the way Rust handles `Result::Err` exits.  It can be addressed but I'm not keen to rework that as part of this PR.