### PR TITLE
feat(main.rs): add app alias for apps command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ const VERSION: &str = concat!(
 #[clap(propagate_version = true)]
 enum CloudCli {
     /// Manage applications deployed to Fermyon Cloud
-    #[clap(subcommand)]
+    #[clap(subcommand, alias = "app")]
     Apps(AppsCommand),
     /// Package and upload an application to the Fermyon Cloud.
     Deploy(DeployCommand),


### PR DESCRIPTION
Allows `spin cloud app ...` usage.