### PR TITLE
chore(Cargo.toml): bump spin crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,8 +3370,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "http",
@@ -3385,8 +3385,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "flate2",
@@ -3401,8 +3401,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -3416,8 +3416,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "redis",
@@ -4636,8 +4636,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4651,8 +4651,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "spin-componentize"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin-componentize?rev=0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d#0aa9622d2dafbdacae55b1fd62eb5bb36bf84b2d"
+source = "git+https://github.com/fermyon/spin-componentize?rev=75fd5117d77415737e337a7fd15ed3317e2ad7a5#75fd5117d77415737e337a7fd15ed3317e2ad7a5"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.29.0",
@@ -4674,8 +4674,8 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4692,8 +4692,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4710,8 +4710,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "http",
@@ -4725,8 +4725,8 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-azure"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-redis"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "redis",
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4782,11 +4782,23 @@ dependencies = [
 
 [[package]]
 name = "spin-llm"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "bytesize",
+ "llm",
+ "spin-app",
+ "spin-core",
+ "spin-world",
+]
+
+[[package]]
+name = "spin-llm-local"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
+dependencies = [
+ "anyhow",
  "candle-core",
  "candle-nn",
  "chrono",
@@ -4796,20 +4808,35 @@ dependencies = [
  "rand 0.8.5",
  "safetensors",
  "serde",
- "spin-app",
  "spin-core",
+ "spin-llm",
  "spin-world",
  "terminal",
  "tokenizers",
  "tokio",
  "tracing",
- "uuid",
+]
+
+[[package]]
+name = "spin-llm-remote-http"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
+dependencies = [
+ "anyhow",
+ "http",
+ "llm",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "spin-core",
+ "spin-llm",
+ "spin-world",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4844,8 +4871,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "indexmap 1.9.3",
  "serde",
@@ -4855,8 +4882,8 @@ dependencies = [
 
 [[package]]
 name = "spin-oci"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4880,8 +4907,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4894,8 +4921,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-inproc"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4909,12 +4936,13 @@ dependencies = [
 
 [[package]]
 name = "spin-sqlite-libsql"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
  "libsql-client",
+ "rusqlite",
  "spin-sqlite",
  "spin-world",
  "sqlparser",
@@ -4923,8 +4951,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4950,6 +4978,8 @@ dependencies = [
  "spin-key-value-redis",
  "spin-key-value-sqlite",
  "spin-llm",
+ "spin-llm-local",
+ "spin-llm-remote-http",
  "spin-loader",
  "spin-manifest",
  "spin-sqlite",
@@ -4966,8 +4996,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4999,8 +5029,8 @@ dependencies = [
 
 [[package]]
 name = "spin-world"
-version = "1.5.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+version = "1.6.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "wasmtime",
 ]
@@ -5213,7 +5243,7 @@ dependencies = [
 [[package]]
 name = "terminal"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.5.0#ca08dd933de32fe09f4c318fbbc1f04853f2085f"
+source = "git+https://github.com/fermyon/spin?rev=8cb61d9babaae3737c8033de5ea8d3304919de80#8cb61d9babaae3737c8033de5ea8d3304919de80"
 dependencies = [
  "atty",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 sha2 = "0.10.2"
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-spin-http = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
-terminal = { git = "https://github.com/fermyon/spin", tag = "v1.5.0" }
+spin-common = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+spin-loader = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+spin-manifest = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+spin-http = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+spin-oci = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
+terminal = { git = "https://github.com/fermyon/spin", rev = "8cb61d9babaae3737c8033de5ea8d3304919de80" }
 tempfile = "3.3.0"
 url = "2.3"
 uuid = { version = "1.3", features = ["v4"] }


### PR DESCRIPTION
Bumps to current HEAD commit of Spin, particularly to get https://github.com/fermyon/spin/commit/d041cc0470c39a341de7b709e7cab5e7d5a011ef

Closes https://github.com/fermyon/cloud-plugin/issues/101