### PR TITLE
Fix silent cancellation when app db already fulfilled

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -769,7 +769,7 @@ async fn create_and_link_databases_for_existing_app(
             }
         }
     }
-    Ok(None)
+    Ok(Some(()))
 }
 
 async fn link_databases(


### PR DESCRIPTION
There is a bug in current `main` where if:

* An app already exists in Cloud
* The app declares a SQLite database
* The SQLite database is already fulfilled

then it mistakenly returns "user cancelled" from the database linking function, causing the deployment to silently nope out.  Basically apps with databases will fail to upgrade without reporting any error.

Before:

```
ivan@hecate:~/testing/sqlmadness$ spin cloud deploy
Uploading sqlmadness version 0.1.0-rcfcbd78 to Fermyon Cloud...
Deploying...
```

With this change:

```
ivan@hecate:~/testing/sqlmadness$ spin cloud deploy
Uploading sqlmadness version 0.1.0-r0de736f to Fermyon Cloud...
Deploying...
Waiting for application to become ready........ ready
Available Routes:
  sqlmadness: https://sqlmadness-ax7chkqb.fermyon.app (wildcard)
```

I don't believe the new app case is affected.