### PR TITLE
chore(Cargo.toml): bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cloud"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 


### PR DESCRIPTION
😬 I forgot to bump the version for this plugin prior to last week's release.

We can either follow up with a 0.3.1 version bump + release soon after (to get correctly-versioned plugin binaries) or wait and continue with a 0.4.0 release with the features/fixes that have landed on main since.