### PR TITLE
chore(Cargo.toml): bump to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "cloud"
 description = "Commands for publishing applications to the Fermyon Cloud."
-version = "0.2.0"
+version = "0.4.0"
 spin_compatibility = ">=1.3"
 license = "Apache-2.0"
 homepage = "https://github.com/fermyon/cloud-plugin"


### PR DESCRIPTION
Bumping the plugin version in anticipation of the next 0.4.0 release.

Release will include: https://github.com/fermyon/cloud-plugin/compare/v0.3.0...main