### PR TITLE
docs(release-process.md): bump version in spin-pluginify.toml as well

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -4,7 +4,7 @@ To cut a new release of the Cloud plugin, you will need to do the following:
 
 1. Confirm that [CI is green](https://fermyon/cloud-plugin/actions) for the commit selected to be tagged and released.
 
-1. Change the version number in [Cargo.toml](./Cargo.toml) and run `cargo build --release`.
+1. Change the version number in [Cargo.toml](./Cargo.toml) and [spin-pluginify.toml](./spin-pluginify.toml) and run `cargo build --release`.
 
 1. Create a pull request with these changes and merge once approved.
 


### PR DESCRIPTION
Currently the plugin version is also tracked in the spin-pluginify.toml file, so adding a mention to keep in sync.

We could also entertain using some other version string in the file so that we aren't obligated to keep it in sync... or PR a feature to the upstream repo wherein pluginify might auto-detect the version :)  cc @itowlson 