### PR TITLE
Framework for testing interactions with `CloudClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ name = "cloud"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cloud-openapi",
  "mime_guess",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "async-trait",
  "cloud-openapi",
  "mime_guess",
+ "mockall",
  "reqwest",
  "semver",
  "serde",
@@ -732,6 +733,7 @@ dependencies = [
  "dialoguer",
  "dirs 5.0.1",
  "lazy_static",
+ "mockall",
  "oci-distribution",
  "openssl",
  "rand 0.8.5",
@@ -1268,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1401,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
@@ -1562,6 +1576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1613,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs-set-times"
@@ -2694,6 +2723,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +2874,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -3378,6 +3440,36 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "priority-queue"
@@ -4943,6 +5035,12 @@ dependencies = [
  "once_cell",
  "termcolor",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ vergen = { version = "^8.2.1", default-features = false, features = [
 
 [dev-dependencies]
 mockall = "0.11"
+cloud = { path = "crates/cloud", features = ["mocks"] }
 
 [patch.crates-io]
 # Using fork to bump nested dep sqlite3-parser to 0.9.0 for Windows build fix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ vergen = { version = "^8.2.1", default-features = false, features = [
   "cargo",
 ] }
 
+[dev-dependencies]
+mockall = "0.11"
+
 [patch.crates-io]
 # Using fork to bump nested dep sqlite3-parser to 0.9.0 for Windows build fix
 # Pending related upstream PR https://github.com/libsql/libsql-client-rs/pull/32

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1.73"
 cloud-openapi = { workspace = true }
 mime_guess = { version = "2.0" }
 reqwest = { version = "0.11", features = ["stream"] }

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { version = "1.17", features = ["full"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 tracing = { workspace = true }
 uuid = "1"
+
+[features]
+mocks = []

--- a/crates/cloud/Cargo.toml
+++ b/crates/cloud/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1.73"
 cloud-openapi = { workspace = true }
 mime_guess = { version = "2.0" }
+mockall = "0.11.4"
 reqwest = { version = "0.11", features = ["stream"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use cloud_openapi::{
     apis::{
         self,
@@ -36,6 +37,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
+use crate::CloudClientInterface;
+
 const JSON_MIME_TYPE: &str = "application/json";
 
 pub struct Client {
@@ -49,43 +52,9 @@ pub struct ConnectionConfig {
     pub url: String,
 }
 
-impl Client {
-    pub fn new(conn_info: ConnectionConfig) -> Self {
-        let mut headers = header::HeaderMap::new();
-        headers.insert(header::ACCEPT, JSON_MIME_TYPE.parse().unwrap());
-        headers.insert(header::CONTENT_TYPE, JSON_MIME_TYPE.parse().unwrap());
-
-        let base_path = match conn_info.url.strip_suffix('/') {
-            Some(s) => s.to_owned(),
-            None => conn_info.url,
-        };
-
-        let configuration = Configuration {
-            base_path,
-            user_agent: Some(format!(
-                "{}/{} spin/{}",
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION"),
-                std::env::var("SPIN_VERSION").unwrap_or_else(|_| "0".to_string())
-            )),
-            client: reqwest::Client::builder()
-                .danger_accept_invalid_certs(conn_info.insecure)
-                .default_headers(headers)
-                .build()
-                .unwrap(),
-            basic_auth: None,
-            oauth_access_token: None,
-            bearer_access_token: None,
-            api_key: Some(ApiKey {
-                prefix: Some("Bearer".to_owned()),
-                key: conn_info.token,
-            }),
-        };
-
-        Self { configuration }
-    }
-
-    pub async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem> {
+#[async_trait]
+impl CloudClientInterface for Client {
+    async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem> {
         api_device_codes_post(
             &self.configuration,
             CreateDeviceCodeCommand { client_id },
@@ -95,7 +64,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn login(&self, token: String) -> Result<TokenInfo> {
+    async fn login(&self, token: String) -> Result<TokenInfo> {
         // When the new OpenAPI specification is released, manually crafting
         // the request should no longer be necessary.
         let response = self
@@ -119,7 +88,7 @@ impl Client {
             .context("Failed to parse response")
     }
 
-    pub async fn refresh_token(&self, token: String, refresh_token: String) -> Result<TokenInfo> {
+    async fn refresh_token(&self, token: String, refresh_token: String) -> Result<TokenInfo> {
         api_auth_tokens_refresh_post(
             &self.configuration,
             RefreshTokenCommand {
@@ -132,7 +101,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn add_app(&self, name: &str, storage_id: &str) -> Result<Uuid> {
+    async fn add_app(&self, name: &str, storage_id: &str) -> Result<Uuid> {
         api_apps_post(
             &self.configuration,
             CreateAppCommand {
@@ -146,19 +115,19 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn remove_app(&self, id: String) -> Result<()> {
+    async fn remove_app(&self, id: String) -> Result<()> {
         api_apps_id_delete(&self.configuration, &id, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn get_app(&self, id: String) -> Result<AppItem> {
+    async fn get_app(&self, id: String) -> Result<AppItem> {
         api_apps_id_get(&self.configuration, &id, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn list_apps(&self, page_size: i32, page_index: Option<i32>) -> Result<AppItemPage> {
+    async fn list_apps(&self, page_size: i32, page_index: Option<i32>) -> Result<AppItemPage> {
         api_apps_get(
             &self.configuration,
             None,
@@ -172,13 +141,13 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn get_channel_by_id(&self, id: &str) -> Result<ChannelItem> {
+    async fn get_channel_by_id(&self, id: &str) -> Result<ChannelItem> {
         api_channels_id_get(&self.configuration, id, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn list_channels(&self) -> Result<ChannelItemPage> {
+    async fn list_channels(&self) -> Result<ChannelItemPage> {
         api_channels_get(
             &self.configuration,
             Some(""),
@@ -192,7 +161,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn list_channels_next(&self, previous: &ChannelItemPage) -> Result<ChannelItemPage> {
+    async fn list_channels_next(&self, previous: &ChannelItemPage) -> Result<ChannelItemPage> {
         api_channels_get(
             &self.configuration,
             Some(""),
@@ -206,7 +175,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn add_channel(
+    async fn add_channel(
         &self,
         app_id: Uuid,
         name: String,
@@ -226,7 +195,7 @@ impl Client {
             .map_err(format_response_error)
     }
 
-    pub async fn patch_channel(
+    async fn patch_channel(
         &self,
         id: Uuid,
         name: Option<String>,
@@ -290,19 +259,19 @@ impl Client {
         }
     }
 
-    pub async fn remove_channel(&self, id: String) -> Result<()> {
+    async fn remove_channel(&self, id: String) -> Result<()> {
         api_channels_id_delete(&self.configuration, &id, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn channel_logs(&self, id: String) -> Result<GetChannelLogsVm> {
+    async fn channel_logs(&self, id: String) -> Result<GetChannelLogsVm> {
         api_channels_id_logs_get(&self.configuration, &id, None, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn add_revision(
+    async fn add_revision(
         &self,
         app_storage_id: String,
         revision_number: String,
@@ -319,13 +288,13 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn list_revisions(&self) -> anyhow::Result<RevisionItemPage> {
+    async fn list_revisions(&self) -> anyhow::Result<RevisionItemPage> {
         api_revisions_get(&self.configuration, None, None, None, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn list_revisions_next(
+    async fn list_revisions_next(
         &self,
         previous: &RevisionItemPage,
     ) -> anyhow::Result<RevisionItemPage> {
@@ -340,7 +309,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn add_key_value_pair(
+    async fn add_key_value_pair(
         &self,
         app_id: Uuid,
         store_name: String,
@@ -361,7 +330,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn add_variable_pair(
+    async fn add_variable_pair(
         &self,
         app_id: Uuid,
         variable: String,
@@ -380,7 +349,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn delete_variable_pair(&self, app_id: Uuid, variable: String) -> anyhow::Result<()> {
+    async fn delete_variable_pair(&self, app_id: Uuid, variable: String) -> anyhow::Result<()> {
         api_variable_pairs_delete(
             &self.configuration,
             DeleteVariablePairCommand { app_id, variable },
@@ -390,14 +359,14 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn get_variable_pairs(&self, app_id: Uuid) -> anyhow::Result<Vec<String>> {
+    async fn get_variable_pairs(&self, app_id: Uuid) -> anyhow::Result<Vec<String>> {
         let list = api_variable_pairs_get(&self.configuration, GetVariablesQuery { app_id }, None)
             .await
             .map_err(format_response_error)?;
         Ok(list.vars)
     }
 
-    pub async fn create_database(
+    async fn create_database(
         &self,
         name: String,
         resource_label: Option<ResourceLabel>,
@@ -419,7 +388,7 @@ impl Client {
         .map_err(format_response_error)
     }
 
-    pub async fn execute_sql(&self, database: String, statement: String) -> anyhow::Result<()> {
+    async fn execute_sql(&self, database: String, statement: String) -> anyhow::Result<()> {
         api_sql_databases_execute_post(
             &self.configuration,
             ExecuteSqlStatementCommand {
@@ -434,13 +403,13 @@ impl Client {
         Ok(())
     }
 
-    pub async fn delete_database(&self, name: String) -> anyhow::Result<()> {
+    async fn delete_database(&self, name: String) -> anyhow::Result<()> {
         api_sql_databases_delete(&self.configuration, DeleteSqlDatabaseCommand { name }, None)
             .await
             .map_err(format_response_error)
     }
 
-    pub async fn get_databases(&self, app_id: Option<Uuid>) -> anyhow::Result<Vec<Database>> {
+    async fn get_databases(&self, app_id: Option<Uuid>) -> anyhow::Result<Vec<Database>> {
         let list = api_sql_databases_get(
             &self.configuration,
             GetSqlDatabasesQuery {
@@ -453,7 +422,7 @@ impl Client {
         Ok(list.databases)
     }
 
-    pub async fn create_database_link(
+    async fn create_database_link(
         &self,
         database: &str,
         resource_label: ResourceLabel,
@@ -463,7 +432,7 @@ impl Client {
             .map_err(format_response_error)
     }
 
-    pub async fn remove_database_link(
+    async fn remove_database_link(
         &self,
         database: &str,
         resource_label: ResourceLabel,
@@ -473,10 +442,47 @@ impl Client {
             .map_err(format_response_error)
     }
 
-    pub async fn rename_database(&self, database: String, new_name: String) -> anyhow::Result<()> {
+    async fn rename_database(&self, database: String, new_name: String) -> anyhow::Result<()> {
         api_sql_databases_database_rename_patch(&self.configuration, &database, &new_name, None)
             .await
             .map_err(format_response_error)
+    }
+}
+
+impl Client {
+    pub fn new(conn_info: ConnectionConfig) -> Self {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(header::ACCEPT, JSON_MIME_TYPE.parse().unwrap());
+        headers.insert(header::CONTENT_TYPE, JSON_MIME_TYPE.parse().unwrap());
+
+        let base_path = match conn_info.url.strip_suffix('/') {
+            Some(s) => s.to_owned(),
+            None => conn_info.url,
+        };
+
+        let configuration = Configuration {
+            base_path,
+            user_agent: Some(format!(
+                "{}/{} spin/{}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION"),
+                std::env::var("SPIN_VERSION").unwrap_or_else(|_| "0".to_string())
+            )),
+            client: reqwest::Client::builder()
+                .danger_accept_invalid_certs(conn_info.insecure)
+                .default_headers(headers)
+                .build()
+                .unwrap(),
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_key: Some(ApiKey {
+                prefix: Some("Bearer".to_owned()),
+                key: conn_info.token,
+            }),
+        };
+
+        Self { configuration }
     }
 }
 
@@ -511,36 +517,23 @@ fn format_response_error<T>(e: Error<T>) -> anyhow::Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct PatchChannelCommand {
+struct PatchChannelCommand {
     #[serde(rename = "channelId", skip_serializing_if = "Option::is_none")]
-    pub channel_id: Option<uuid::Uuid>,
+    channel_id: Option<uuid::Uuid>,
     #[serde(
         rename = "environmentVariables",
         skip_serializing_if = "Option::is_none"
     )]
-    pub environment_variables: Option<Vec<EnvironmentVariableItem>>,
+    environment_variables: Option<Vec<EnvironmentVariableItem>>,
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    name: Option<String>,
     #[serde(
         rename = "revisionSelectionStrategy",
         skip_serializing_if = "Option::is_none"
     )]
-    pub revision_selection_strategy: Option<ChannelRevisionSelectionStrategy>,
+    revision_selection_strategy: Option<ChannelRevisionSelectionStrategy>,
     #[serde(rename = "rangeRule", skip_serializing_if = "Option::is_none")]
-    pub range_rule: Option<String>,
+    range_rule: Option<String>,
     #[serde(rename = "activeRevisionId", skip_serializing_if = "Option::is_none")]
-    pub active_revision_id: Option<uuid::Uuid>,
-}
-
-impl PatchChannelCommand {
-    pub fn new() -> PatchChannelCommand {
-        PatchChannelCommand {
-            channel_id: None,
-            environment_variables: None,
-            name: None,
-            revision_selection_strategy: None,
-            range_rule: None,
-            active_revision_id: None,
-        }
-    }
+    active_revision_id: Option<uuid::Uuid>,
 }

--- a/crates/cloud/src/client_interface.rs
+++ b/crates/cloud/src/client_interface.rs
@@ -1,0 +1,115 @@
+use crate::client::ConnectionConfig;
+use anyhow::Result;
+use async_trait::async_trait;
+use cloud_openapi::models::{
+    AppItem, AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy, Database,
+    DeviceCodeItem, EnvironmentVariableItem, GetChannelLogsVm, ResourceLabel, RevisionItemPage,
+    TokenInfo,
+};
+
+use std::string::String;
+use uuid::Uuid;
+
+#[async_trait]
+pub trait CloudClientInterface {
+    async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem>;
+
+    async fn login(&self, token: String) -> Result<TokenInfo>;
+
+    async fn refresh_token(&self, token: String, refresh_token: String) -> Result<TokenInfo>;
+
+    async fn add_app(&self, name: &str, storage_id: &str) -> Result<Uuid>;
+
+    async fn remove_app(&self, id: String) -> Result<()>;
+
+    async fn get_app(&self, id: String) -> Result<AppItem>;
+
+    async fn list_apps(&self, page_size: i32, page_index: Option<i32>) -> Result<AppItemPage>;
+
+    async fn get_channel_by_id(&self, id: &str) -> Result<ChannelItem>;
+
+    async fn list_channels(&self) -> Result<ChannelItemPage>;
+
+    async fn list_channels_next(&self, previous: &ChannelItemPage) -> Result<ChannelItemPage>;
+
+    async fn add_channel(
+        &self,
+        app_id: Uuid,
+        name: String,
+        revision_selection_strategy: ChannelRevisionSelectionStrategy,
+        range_rule: Option<String>,
+        active_revision_id: Option<Uuid>,
+    ) -> anyhow::Result<Uuid>;
+
+    async fn patch_channel(
+        &self,
+        id: Uuid,
+        name: Option<String>,
+        revision_selection_strategy: Option<ChannelRevisionSelectionStrategy>,
+        range_rule: Option<String>,
+        active_revision_id: Option<Uuid>,
+        environment_variables: Option<Vec<EnvironmentVariableItem>>,
+    ) -> anyhow::Result<()>;
+
+    async fn remove_channel(&self, id: String) -> Result<()>;
+
+    async fn channel_logs(&self, id: String) -> Result<GetChannelLogsVm>;
+
+    async fn add_revision(
+        &self,
+        app_storage_id: String,
+        revision_number: String,
+    ) -> anyhow::Result<()>;
+
+    async fn list_revisions(&self) -> anyhow::Result<RevisionItemPage>;
+
+    async fn list_revisions_next(
+        &self,
+        previous: &RevisionItemPage,
+    ) -> anyhow::Result<RevisionItemPage>;
+
+    async fn add_key_value_pair(
+        &self,
+        app_id: Uuid,
+        store_name: String,
+        key: String,
+        value: String,
+    ) -> anyhow::Result<()>;
+
+    async fn add_variable_pair(
+        &self,
+        app_id: Uuid,
+        variable: String,
+        value: String,
+    ) -> anyhow::Result<()>;
+
+    async fn delete_variable_pair(&self, app_id: Uuid, variable: String) -> anyhow::Result<()>;
+
+    async fn get_variable_pairs(&self, app_id: Uuid) -> anyhow::Result<Vec<String>>;
+
+    async fn create_database(
+        &self,
+        name: String,
+        resource_label: Option<ResourceLabel>,
+    ) -> anyhow::Result<()>;
+
+    async fn execute_sql(&self, database: String, statement: String) -> anyhow::Result<()>;
+
+    async fn delete_database(&self, name: String) -> anyhow::Result<()>;
+
+    async fn get_databases(&self, app_id: Option<Uuid>) -> anyhow::Result<Vec<Database>>;
+
+    async fn create_database_link(
+        &self,
+        database: &str,
+        resource_label: ResourceLabel,
+    ) -> anyhow::Result<()>;
+
+    async fn remove_database_link(
+        &self,
+        database: &str,
+        resource_label: ResourceLabel,
+    ) -> anyhow::Result<()>;
+
+    async fn rename_database(&self, database: String, new_name: String) -> anyhow::Result<()>;
+}

--- a/crates/cloud/src/client_interface.rs
+++ b/crates/cloud/src/client_interface.rs
@@ -5,12 +5,11 @@ use cloud_openapi::models::{
     DeviceCodeItem, EnvironmentVariableItem, GetChannelLogsVm, ResourceLabel, RevisionItemPage,
     TokenInfo,
 };
-use mockall::*;
 
 use std::string::String;
 use uuid::Uuid;
 
-#[automock]
+#[cfg_attr(feature = "mocks", mockall::automock)]
 #[async_trait]
 pub trait CloudClientInterface {
     async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem>;

--- a/crates/cloud/src/client_interface.rs
+++ b/crates/cloud/src/client_interface.rs
@@ -1,4 +1,3 @@
-use crate::client::ConnectionConfig;
 use anyhow::Result;
 use async_trait::async_trait;
 use cloud_openapi::models::{
@@ -6,10 +5,12 @@ use cloud_openapi::models::{
     DeviceCodeItem, EnvironmentVariableItem, GetChannelLogsVm, ResourceLabel, RevisionItemPage,
     TokenInfo,
 };
+use mockall::*;
 
 use std::string::String;
 use uuid::Uuid;
 
+#[automock]
 #[async_trait]
 pub trait CloudClientInterface {
     async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem>;

--- a/crates/cloud/src/lib.rs
+++ b/crates/cloud/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
 mod client_interface;
 pub use client_interface::CloudClientInterface;
+#[cfg(feature = "mocks")]
 pub use client_interface::MockCloudClientInterface;

--- a/crates/cloud/src/lib.rs
+++ b/crates/cloud/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod client;
 mod client_interface;
 pub use client_interface::CloudClientInterface;
+pub use client_interface::MockCloudClientInterface;

--- a/crates/cloud/src/lib.rs
+++ b/crates/cloud/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod client;
+mod client_interface;
+pub use client_interface::CloudClientInterface;

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -2,6 +2,7 @@ use crate::commands::{client_and_app_id, create_cloud_client};
 use crate::opts::*;
 use anyhow::{Context, Result};
 use clap::{Args, Parser};
+use cloud::CloudClientInterface;
 use cloud_openapi::models::{AppItem, AppItemPage, ValidationStatus};
 
 #[derive(Parser, Debug)]

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::{Args, Parser};
-use cloud::client::Client as CloudClient;
 use cloud::CloudClientInterface;
 use cloud_openapi::models::{Database, ResourceLabel};
+use uuid::Uuid;
 
 use crate::commands::{client_and_app_id, sqlite::find_database_link};
 use crate::opts::*;
@@ -43,16 +43,19 @@ struct CommonArgs {
 impl LinkCommand {
     pub async fn run(self) -> Result<()> {
         match self {
-            Self::Sqlite(cmd) => cmd.link().await,
+            Self::Sqlite(cmd) => {
+                let (client, app_id) =
+                    client_and_app_id(cmd.common.deployment_env_id.as_deref(), &cmd.app).await?;
+                cmd.link(client, app_id).await
+            }
         }
     }
 }
 
 impl SqliteLinkCommand {
-    async fn link(self) -> Result<()> {
-        let (client, app_id) =
-            client_and_app_id(self.common.deployment_env_id.as_deref(), &self.app).await?;
-        let database = CloudClient::get_databases(&client, None)
+    async fn link(self, client: impl CloudClientInterface, app_id: Uuid) -> Result<()> {
+        let database = client
+            .get_databases(None)
             .await
             .context("could not fetch databases")?
             .into_iter()
@@ -61,7 +64,8 @@ impl SqliteLinkCommand {
             anyhow::bail!(r#"Database "{}" does not exist"#, self.database)
         }
 
-        let databases_for_app = CloudClient::get_databases(&client, Some(app_id))
+        let databases_for_app = client
+            .get_databases(Some(app_id))
             .await
             .context("Problem listing links")?;
         let (this_db, other_dbs): (Vec<&Database>, Vec<&Database>) = databases_for_app
@@ -101,14 +105,16 @@ impl SqliteLinkCommand {
                     .unwrap_or_default()
                 {
                     // TODO: use a relink API to remove any downtime
-                    CloudClient::remove_database_link(&client, &link.resource, link.resource_label)
+                    client
+                        .remove_database_link(&link.resource, link.resource_label)
                         .await?;
                     let resource_label = ResourceLabel {
                         app_id,
                         label: self.label,
                         app_name: None,
                     };
-                    CloudClient::create_database_link(&client, &self.database, resource_label)
+                    client
+                        .create_database_link(&self.database, resource_label)
                         .await?;
                     println!("{success_msg}");
                 } else {
@@ -121,7 +127,9 @@ impl SqliteLinkCommand {
                     label: self.label,
                     app_name: None,
                 };
-                CloudClient::create_database_link(&client, &self.database, resource_label).await?;
+                client
+                    .create_database_link(&self.database, resource_label)
+                    .await?;
                 println!("{success_msg}");
             }
         }
@@ -180,7 +188,7 @@ impl SqliteUnlinkCommand {
                 )
             })?;
 
-        CloudClient::remove_database_link(&client, &database, label).await?;
+        client.remove_database_link(&database, label).await?;
         println!("Database '{database}' no longer linked to app {}", self.app);
         Ok(())
     }
@@ -207,4 +215,101 @@ impl Link {
             _ => "UNKNOWN",
         }
     }
+}
+
+#[cfg(test)]
+mod link_tests {
+    use super::*;
+    use cloud::MockCloudClientInterface;
+    #[tokio::test]
+    async fn test_sqlite_link_error_database_does_not_exist() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = SqliteLinkCommand {
+            app: "app".to_string(),
+            database: "does-not-exist".to_string(),
+            label: "label".to_string(),
+            common: Default::default(),
+        };
+        let app_id = Uuid::new_v4();
+        let dbs = vec![
+            Database::new("db1".to_string(), vec![]),
+            Database::new("db2".to_string(), vec![]),
+        ];
+        mock.expect_get_databases()
+            .returning(move |_| Ok(dbs.to_owned()));
+
+        let result = command.link(mock, app_id).await;
+        match result {
+            Ok(_) => panic!("Expected error"),
+            Err(err) => assert_eq!(
+                err.to_string(),
+                r#"Database "does-not-exist" does not exist"#
+            ),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_link_success() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = SqliteLinkCommand {
+            app: "app".to_string(),
+            database: "db1".to_string(),
+            label: "label".to_string(),
+            common: Default::default(),
+        };
+        let app_id = Uuid::new_v4();
+        let dbs = vec![
+            Database::new("db1".to_string(), vec![]),
+            Database::new("db2".to_string(), vec![]),
+        ];
+        mock.expect_get_databases()
+            .returning(move |_| Ok(dbs.to_owned()));
+        let expected_resource_label = ResourceLabel {
+            app_id,
+            label: command.label.clone(),
+            app_name: None,
+        };
+        mock.expect_create_database_link()
+            .withf(move |db, rl| db == "db1" && rl == &expected_resource_label)
+            .returning(|_, _| Ok(()));
+        command.link(mock, app_id).await
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_link_error_link_exists() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = SqliteLinkCommand {
+            app: "app".to_string(),
+            database: "db1".to_string(),
+            label: "label".to_string(),
+            common: Default::default(),
+        };
+        let app_id = Uuid::new_v4();
+        let dbs = vec![
+            Database::new(
+                "db1".to_string(),
+                vec![ResourceLabel {
+                    app_id,
+                    label: command.label.clone(),
+                    app_name: Some("app".to_string()),
+                }],
+            ),
+            Database::new("db2".to_string(), vec![]),
+        ];
+        mock.expect_get_databases()
+            .returning(move |_| Ok(dbs.to_owned()));
+        let result = command.link(mock, app_id).await;
+        match result {
+            Ok(_) => panic!("Expected error"),
+            Err(err) => assert_eq!(
+                err.to_string(),
+                r#"Database "db1" is already linked to app "app" with the label "label""#
+            ),
+        }
+        Ok(())
+    }
+
+    // TODO: add test for test_sqlite_link_error_link_exists_different_database() once
+    // there is a flag to avoid prompts
 }

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{Args, Parser};
 use cloud::client::Client as CloudClient;
+use cloud::CloudClientInterface;
 use cloud_openapi::models::{Database, ResourceLabel};
 
 use crate::commands::{client_and_app_id, sqlite::find_database_link};

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use cloud::client::{Client, ConnectionConfig};
+use cloud::{
+    client::{Client, ConnectionConfig},
+    CloudClientInterface,
+};
 use cloud_openapi::models::DeviceCodeItem;
 use cloud_openapi::models::TokenInfo;
 use serde::Deserialize;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,7 +7,10 @@ pub mod variables;
 
 use crate::{commands::deploy::login_connection, opts::DEFAULT_APPLIST_PAGE_SIZE};
 use anyhow::{Context, Result};
-use cloud::client::{Client as CloudClient, ConnectionConfig};
+use cloud::{
+    client::{Client as CloudClient, ConnectionConfig},
+    CloudClientInterface,
+};
 use uuid::Uuid;
 
 pub(crate) async fn create_cloud_client(deployment_env_id: Option<&str>) -> Result<CloudClient> {

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -4,7 +4,7 @@ use crate::opts::*;
 use anyhow::bail;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, ValueEnum};
-use cloud::client::Client as CloudClient;
+use cloud::{client::Client as CloudClient, CloudClientInterface};
 use cloud_openapi::models::Database;
 use cloud_openapi::models::ResourceLabel;
 use comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED;

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -465,14 +465,13 @@ mod sqlite_tests {
             Database::new("db1".to_string(), vec![]),
             Database::new("db2".to_string(), vec![]),
         ];
-        mock.expect_get_databases()
-            .returning(move |_| Ok(dbs.to_owned()));
+        mock.expect_get_databases().return_once(move |_| Ok(dbs));
 
         let result = command.run(mock).await;
-        match result {
-            Ok(_) => panic!("Expected error"),
-            Err(err) => assert_eq!(err.to_string(), r#"Database "db1" already exists"#),
-        }
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            r#"Database "db1" already exists"#
+        );
         Ok(())
     }
 
@@ -484,8 +483,7 @@ mod sqlite_tests {
             common: Default::default(),
         };
         let dbs = vec![Database::new("db2".to_string(), vec![])];
-        mock.expect_get_databases()
-            .returning(move |_| Ok(dbs.to_owned()));
+        mock.expect_get_databases().return_once(move |_| Ok(dbs));
         mock.expect_create_database()
             .withf(move |db, rl| db == "db1" && rl.is_none())
             .returning(|_, _| Ok(()));
@@ -503,10 +501,10 @@ mod sqlite_tests {
         mock.expect_get_databases().returning(move |_| Ok(vec![]));
 
         let result = command.run(mock).await;
-        match result {
-            Ok(_) => panic!("Expected error"),
-            Err(err) => assert_eq!(err.to_string(), r#"No database found with name "db1""#),
-        }
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            r#"No database found with name "db1""#
+        );
         Ok(())
     }
 

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -4,7 +4,7 @@ use crate::opts::*;
 use anyhow::bail;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, ValueEnum};
-use cloud::{client::Client as CloudClient, CloudClientInterface};
+use cloud::CloudClientInterface;
 use cloud_openapi::models::Database;
 use cloud_openapi::models::ResourceLabel;
 use comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED;
@@ -151,8 +151,14 @@ struct CommonArgs {
 impl SqliteCommand {
     pub async fn run(self) -> Result<()> {
         match self {
-            Self::Create(cmd) => cmd.run().await,
-            Self::Delete(cmd) => cmd.run().await,
+            Self::Create(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                cmd.run(client).await
+            }
+            Self::Delete(cmd) => {
+                let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
+                cmd.run(client).await
+            }
             Self::Execute(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
             Self::Rename(cmd) => cmd.run().await,
@@ -161,15 +167,16 @@ impl SqliteCommand {
 }
 
 impl CreateCommand {
-    pub async fn run(self) -> Result<()> {
-        let client = create_cloud_client(self.common.deployment_env_id.as_deref()).await?;
-        let list = CloudClient::get_databases(&client, None)
+    pub async fn run(self, client: impl CloudClientInterface) -> Result<()> {
+        let list: Vec<Database> = client
+            .get_databases(None)
             .await
             .context("Problem fetching databases")?;
         if list.iter().any(|d| d.name == self.name) {
-            anyhow::bail!("Database {} already exists", self.name)
+            anyhow::bail!(r#"Database "{}" already exists"#, self.name)
         }
-        CloudClient::create_database(&client, self.name.clone(), None)
+        client
+            .create_database(self.name.clone(), None)
             .await
             .with_context(|| format!("Problem creating database {}", self.name))?;
         println!("Database \"{}\" created", self.name);
@@ -178,9 +185,9 @@ impl CreateCommand {
 }
 
 impl DeleteCommand {
-    pub async fn run(self) -> Result<()> {
-        let client = create_cloud_client(self.common.deployment_env_id.as_deref()).await?;
-        let list = CloudClient::get_databases(&client, None)
+    pub async fn run(self, client: impl CloudClientInterface) -> Result<()> {
+        let list = client
+            .get_databases(None)
             .await
             .context("Problem fetching databases")?;
         let found = list.iter().find(|d| d.name == self.name);
@@ -189,7 +196,8 @@ impl DeleteCommand {
             Some(db) => {
                 // TODO: Fail if apps exist that are currently using a database
                 if self.yes || prompt_delete_database(&self.name, &db.links)? {
-                    CloudClient::delete_database(&client, self.name.clone())
+                    client
+                        .delete_database(self.name.clone())
                         .await
                         .with_context(|| format!("Problem deleting database {}", self.name))?;
                     println!("Database \"{}\" deleted", self.name);
@@ -203,7 +211,8 @@ impl DeleteCommand {
 impl ExecuteCommand {
     pub async fn run(self) -> Result<()> {
         let client = create_cloud_client(self.common.deployment_env_id.as_deref()).await?;
-        let list = CloudClient::get_databases(&client, None)
+        let list = client
+            .get_databases(None)
             .await
             .context("Problem fetching databases")?;
         if !list.iter().any(|d| d.name == self.name) {
@@ -215,7 +224,8 @@ impl ExecuteCommand {
         } else {
             self.statement
         };
-        CloudClient::execute_sql(&client, self.name, statement)
+        client
+            .execute_sql(self.name, statement)
             .await
             .context("Problem executing SQL")?;
         Ok(())
@@ -323,7 +333,8 @@ struct ResourceLabelJson<'a> {
 impl RenameCommand {
     pub async fn run(self) -> Result<()> {
         let client = create_cloud_client(self.common.deployment_env_id.as_deref()).await?;
-        let list = CloudClient::get_databases(&client, None)
+        let list = client
+            .get_databases(None)
             .await
             .context("Problem fetching databases")?;
         let found = list.iter().find(|d| d.name == self.name);
@@ -436,4 +447,80 @@ pub fn find_database_link(db: &Database, label: &str) -> Option<Link> {
 
 pub fn database_has_link(db: &Database, link: &ResourceLabel) -> bool {
     db.links.iter().any(|l| l == link)
+}
+
+#[cfg(test)]
+mod sqlite_tests {
+    use super::*;
+    use cloud::MockCloudClientInterface;
+
+    #[tokio::test]
+    async fn test_create_error_already_exists() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = CreateCommand {
+            name: "db1".to_string(),
+            common: Default::default(),
+        };
+        let dbs = vec![
+            Database::new("db1".to_string(), vec![]),
+            Database::new("db2".to_string(), vec![]),
+        ];
+        mock.expect_get_databases()
+            .returning(move |_| Ok(dbs.to_owned()));
+
+        let result = command.run(mock).await;
+        match result {
+            Ok(_) => panic!("Expected error"),
+            Err(err) => assert_eq!(err.to_string(), r#"Database "db1" already exists"#),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_success() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = CreateCommand {
+            name: "db1".to_string(),
+            common: Default::default(),
+        };
+        let dbs = vec![Database::new("db2".to_string(), vec![])];
+        mock.expect_get_databases()
+            .returning(move |_| Ok(dbs.to_owned()));
+        mock.expect_create_database()
+            .withf(move |db, rl| db == "db1" && rl.is_none())
+            .returning(|_, _| Ok(()));
+        command.run(mock).await
+    }
+
+    #[tokio::test]
+    async fn test_delete_error_does_not_exist() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = DeleteCommand {
+            name: "db1".to_string(),
+            common: Default::default(),
+            yes: true,
+        };
+        mock.expect_get_databases().returning(move |_| Ok(vec![]));
+
+        let result = command.run(mock).await;
+        match result {
+            Ok(_) => panic!("Expected error"),
+            Err(err) => assert_eq!(err.to_string(), r#"No database found with name "db1""#),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_success() -> Result<()> {
+        let mut mock = MockCloudClientInterface::new();
+        let command = DeleteCommand {
+            name: "db1".to_string(),
+            common: Default::default(),
+            yes: true,
+        };
+        mock.expect_get_databases()
+            .returning(move |_| Ok(vec![Database::new("db1".to_string(), vec![])]));
+        mock.expect_delete_database().returning(|_| Ok(()));
+        command.run(mock).await
+    }
 }

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Args, Parser};
-use cloud::client::Client as CloudClient;
+use cloud::{client::Client as CloudClient, CloudClientInterface};
 use serde::Deserialize;
 use serde_json::from_str;
 use spin_common::arg_parser::parse_kv;


### PR DESCRIPTION
This is a proposed approach to increasing our unit tests in this repository by making the `CloudClient` mockable. It uses the `mockall` crate by having the `CloudClient` implement a `CloudClientInterface` that can be mocked. Also has a few tests for examples.

Pros to this approach:
- Can add more tests to ensure user input is erroring as expected
- Can add tests to ensure we are handling the data returned from the cloud 

Cons:
- As @itowlson [mentions](https://github.com/fermyon/cloud-plugin/issues/124#issuecomment-1749708109), with mocks, tests can be verbose and potentially summed up to "we can confirm it makes this series of API calls but 🤷"
- Requires passing the client as an argument to any testable functions

(I'm sure there are other pros and cons i am forgetting)

fixes https://github.com/fermyon/cloud-plugin/issues/124