### PR TITLE
Remove deploy --buildinfo and --no-buildinfo flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use commands::{
     sqlite::SqliteCommand,
     variables::VariablesCommand,
 };
-use semver::BuildMetadata;
 
 /// Returns build information, similar to: 0.1.0 (2be4034 2022-03-31).
 const VERSION: &str = concat!(
@@ -67,8 +66,4 @@ async fn main() -> Result<(), Error> {
         CloudCli::Link(cmd) => cmd.run().await,
         CloudCli::Unlink(cmd) => cmd.run().await,
     }
-}
-
-pub(crate) fn parse_buildinfo(buildinfo: &str) -> Result<BuildMetadata> {
-    Ok(BuildMetadata::new(buildinfo)?)
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,7 +1,6 @@
 pub const DEFAULT_MANIFEST_FILE: &str = spin_common::paths::DEFAULT_MANIFEST_FILE;
 pub const APP_MANIFEST_FILE_OPT: &str = "APP_MANIFEST_FILE";
 pub const APPLICATION_OPT: &str = "APPLICATION";
-pub const BUILDINFO_OPT: &str = "BUILDINFO";
 pub const FROM_REGISTRY_OPT: &str = "REGISTRY_REFERENCE";
 pub const INSECURE_OPT: &str = "INSECURE";
 pub const CLOUD_SERVER_URL_OPT: &str = "CLOUD_SERVER_URL";


### PR DESCRIPTION
~Exterminates~ Fixes #41.

Tested redeploying an application without changing its version and `deploy` correctly waited for the new version to become ready before reporting completion.
