### PR TITLE
`spin cloud sqlite execute` by label

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -716,7 +716,7 @@ async fn get_database_selection_for_existing_app(
     let databases = client.get_databases(None).await?;
     if databases
         .iter()
-        .any(|d| database_has_link(d, resource_label))
+        .any(|d| database_has_link(d, &resource_label.label, resource_label.app_name.as_deref()))
     {
         return Ok(ExistingAppDatabaseSelection::AlreadyLinked);
     }

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -54,8 +54,8 @@ pub struct DeleteCommand {
 #[derive(Parser, Debug)]
 pub struct ExecuteCommand {
     /// Name of database to execute against
-    #[clap(value_parser = clap::builder::ValueParser::new(disallow_empty))]
-    name: String,
+    #[clap(short = 'd', long = "database", value_parser = clap::builder::ValueParser::new(disallow_empty))]
+    database: String,
 
     ///Statement to execute
     #[clap(value_parser = clap::builder::ValueParser::new(disallow_empty))]
@@ -215,8 +215,8 @@ impl ExecuteCommand {
             .get_databases(None)
             .await
             .context("Problem fetching databases")?;
-        if !list.iter().any(|d| d.name == self.name) {
-            anyhow::bail!("No database found with name \"{}\"", self.name);
+        if !list.iter().any(|d| d.name == self.database) {
+            anyhow::bail!("No database found with name \"{}\"", self.database);
         }
         let statement = if let Some(path) = self.statement.strip_prefix('@') {
             std::fs::read_to_string(path)
@@ -225,7 +225,7 @@ impl ExecuteCommand {
             self.statement
         };
         client
-            .execute_sql(self.name, statement)
+            .execute_sql(self.database, statement)
             .await
             .context("Problem executing SQL")?;
         Ok(())


### PR DESCRIPTION
Fixes #70.

I noticed there was an existing `database_has_link` function but it needs a UUID.  Should I be fetching one in the app case?  I couldn't see how it would help (because the UUID derives from the name anyway), but am probably missing something!
