### PR TITLE
Move some cloud functions to an extension

### DIFF
--- a/crates/cloud/src/client_interface.rs
+++ b/crates/cloud/src/client_interface.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 #[cfg_attr(feature = "mocks", mockall::automock)]
 #[async_trait]
-pub trait CloudClientInterface {
+pub trait CloudClientInterface: Send + Sync {
     async fn create_device_code(&self, client_id: Uuid) -> Result<DeviceCodeItem>;
 
     async fn login(&self, token: String) -> Result<TokenInfo>;

--- a/crates/cloud/src/cloud_client_extensions.rs
+++ b/crates/cloud/src/cloud_client_extensions.rs
@@ -1,0 +1,76 @@
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::CloudClientInterface;
+
+#[async_trait]
+pub trait CloudClientExt {
+    async fn get_app_id(&self, app_name: &str) -> Result<Option<Uuid>>;
+    async fn get_revision_id(&self, app_id: Uuid, version: &str) -> Result<Uuid>;
+    async fn get_channel_id(&self, app_id: Uuid, channel_name: &str) -> Result<Uuid>;
+}
+
+#[async_trait]
+impl<T: CloudClientInterface> CloudClientExt for T {
+    async fn get_app_id(&self, app_name: &str) -> Result<Option<Uuid>> {
+        let apps_vm = self
+            .list_apps(crate::DEFAULT_APPLIST_PAGE_SIZE, None)
+            .await
+            .context("Could not fetch apps")?;
+        let app = apps_vm.items.iter().find(|&x| x.name == app_name);
+        Ok(app.map(|a| a.id))
+    }
+
+    async fn get_revision_id(&self, app_id: Uuid, version: &str) -> Result<Uuid> {
+        let mut revisions = self.list_revisions().await?;
+
+        loop {
+            if let Some(revision) = revisions
+                .items
+                .iter()
+                .find(|&x| x.revision_number == version && x.app_id == app_id)
+            {
+                return Ok(revision.id);
+            }
+
+            if revisions.is_last_page {
+                break;
+            }
+
+            revisions = self.list_revisions_next(&revisions).await?;
+        }
+
+        Err(anyhow!(
+            "No revision with version {} and app id {}",
+            version,
+            app_id
+        ))
+    }
+
+    async fn get_channel_id(&self, app_id: Uuid, channel_name: &str) -> Result<Uuid> {
+        let mut channels_vm = self.list_channels().await?;
+
+        loop {
+            if let Some(channel) = channels_vm
+                .items
+                .iter()
+                .find(|&x| x.app_id == app_id && x.name == channel_name)
+            {
+                return Ok(channel.id);
+            }
+
+            if channels_vm.is_last_page {
+                break;
+            }
+
+            channels_vm = self.list_channels_next(&channels_vm).await?;
+        }
+
+        Err(anyhow!(
+            "No channel with app_id {} and name {}",
+            app_id,
+            channel_name,
+        ))
+    }
+}

--- a/crates/cloud/src/lib.rs
+++ b/crates/cloud/src/lib.rs
@@ -1,5 +1,10 @@
 pub mod client;
 mod client_interface;
+mod cloud_client_extensions;
+
 pub use client_interface::CloudClientInterface;
 #[cfg(feature = "mocks")]
 pub use client_interface::MockCloudClientInterface;
+pub use cloud_client_extensions::CloudClientExt;
+
+pub const DEFAULT_APPLIST_PAGE_SIZE: i32 = 50;

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -2,7 +2,7 @@ use crate::commands::{client_and_app_id, create_cloud_client};
 use crate::opts::*;
 use anyhow::{Context, Result};
 use clap::{Args, Parser};
-use cloud::CloudClientInterface;
+use cloud::{CloudClientInterface, DEFAULT_APPLIST_PAGE_SIZE};
 use cloud_openapi::models::{AppItem, AppItemPage, ValidationStatus};
 
 #[derive(Parser, Debug)]

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -8,4 +8,3 @@ pub const CLOUD_URL_ENV: &str = "CLOUD_URL";
 pub const DEPLOYMENT_ENV_NAME_ENV: &str = "FERMYON_DEPLOYMENT_ENVIRONMENT";
 pub const TOKEN: &str = "TOKEN";
 pub const SPIN_AUTH_TOKEN: &str = "SPIN_AUTH_TOKEN";
-pub const DEFAULT_APPLIST_PAGE_SIZE: i32 = 50;


### PR DESCRIPTION
This is a pure refactor - no behaviour changes.  (Unless I messed up.)

While working on some reorganisation of the `deploy` module, I noticed we had some instance methods that didn't use `self` and in fact seemed more concerned with the `CloudClient` than with the `DeployCommand`.  For me it felt more readable to pull them out as extension methods on the `CloudClientInterface`.  (My main interest was in moving code out of `DeployCommand`, which could be done without traitifying.  But this felt nicer.)

I also noticed that `commands::get_app_id_cloud` and `DeployCommand::try_get_app_id_cloud` did the same thing (modulo one `anyhow::Context`), so unified them.

I removed the `_cloud` suffixes which were inherited from earlier Spin code where they had to be distinguished from Platform (`_hippo`) versions of the operations.  The suffix is no longer needed in the cloud-specific plugin.  I also took the opportunity to change the argument order and make some strings into `&str` because reduced the need for repeated cloning.
