### PR TITLE
Move deploy helpers to submodules and simplify flow

### DIFF
--- a/src/commands/deploy/app_source.rs
+++ b/src/commands/deploy/app_source.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use crate::opts::DEFAULT_MANIFEST_FILE;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum AppSource {
+    None,
+    File(PathBuf),
+    OciRegistry(String),
+    Unresolvable(String),
+}
+
+impl super::DeployCommand {
+    pub(super) fn resolve_app_source(&self) -> AppSource {
+        match (&self.app_source, &self.file_source, &self.registry_source) {
+            (None, None, None) => self.default_manifest_or_none(),
+            (Some(source), None, None) => Self::infer_source(source),
+            (None, Some(file), None) => Self::infer_file_source(file.to_owned()),
+            (None, None, Some(reference)) => AppSource::OciRegistry(reference.to_owned()),
+            _ => AppSource::unresolvable("More than one application source was specified"),
+        }
+    }
+
+    fn default_manifest_or_none(&self) -> AppSource {
+        let default_manifest = PathBuf::from(DEFAULT_MANIFEST_FILE);
+        if default_manifest.exists() {
+            AppSource::File(default_manifest)
+        } else {
+            AppSource::None
+        }
+    }
+
+    fn infer_source(source: &str) -> AppSource {
+        let path = PathBuf::from(source);
+        if path.exists() {
+            Self::infer_file_source(path)
+        } else if spin_oci::is_probably_oci_reference(source) {
+            AppSource::OciRegistry(source.to_owned())
+        } else {
+            AppSource::Unresolvable(format!("File or directory '{source}' not found. If you meant to load from a registry, use the `--from-registry` option."))
+        }
+    }
+
+    fn infer_file_source(path: impl Into<PathBuf>) -> AppSource {
+        match spin_common::paths::resolve_manifest_file_path(path.into()) {
+            Ok(file) => AppSource::File(file),
+            Err(e) => AppSource::Unresolvable(e.to_string()),
+        }
+    }
+}
+
+impl AppSource {
+    fn unresolvable(message: impl Into<String>) -> Self {
+        Self::Unresolvable(message.into())
+    }
+}

--- a/src/commands/deploy/build.rs
+++ b/src/commands/deploy/build.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Context};
+
+use super::app_source::AppSource;
+use crate::spin;
+
+impl AppSource {
+    pub(super) async fn build(&self) -> anyhow::Result<()> {
+        match self {
+            Self::File(manifest_path) => {
+                let spin_bin = spin::bin_path()?;
+
+                let result = tokio::process::Command::new(spin_bin)
+                    .args(["build", "-f"])
+                    .arg(manifest_path)
+                    .status()
+                    .await
+                    .context("Failed to execute `spin build` command")?;
+
+                if result.success() {
+                    Ok(())
+                } else {
+                    Err(anyhow!("Build failed: deployment cancelled"))
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}

--- a/src/commands/deploy/cancellable.rs
+++ b/src/commands/deploy/cancellable.rs
@@ -1,0 +1,4 @@
+pub enum Cancellable<T> {
+    Cancelled,
+    Accepted(T),
+}

--- a/src/commands/deploy/database.rs
+++ b/src/commands/deploy/database.rs
@@ -1,0 +1,213 @@
+use anyhow::{bail, Context, Result};
+use cloud::CloudClientInterface;
+use cloud_openapi::models::{Database, ResourceLabel};
+
+use crate::commands::sqlite::database_has_link;
+use crate::random_name::RandomNameGenerator;
+use std::collections::HashSet;
+use uuid::Uuid;
+
+use super::interaction::Interactor;
+
+// Loops through an app's manifest and creates databases.
+// Returns a list of database and label pairs that should be
+// linked to the app once it is created.
+// Returns None if the user canceled terminal interaction
+pub(super) async fn create_databases_for_new_app(
+    interactor: &impl Interactor,
+    client: &impl CloudClientInterface,
+    app_name: &str,
+    labels: HashSet<String>,
+) -> anyhow::Result<Option<Vec<(String, String)>>> {
+    let mut databases_to_link = Vec::new();
+    for label in labels {
+        let db =
+            match get_database_selection_for_new_app(interactor, app_name, client, &label).await? {
+                DatabaseSelection::Existing(db) => db,
+                DatabaseSelection::New(db) => {
+                    client.create_database(db.clone(), None).await?;
+                    db
+                }
+                // User canceled terminal interaction
+                DatabaseSelection::Cancelled => return Ok(None),
+            };
+        databases_to_link.push((db, label));
+    }
+    Ok(Some(databases_to_link))
+}
+
+// Loops through an updated app's manifest and creates and links any newly referenced databases.
+// Returns None if the user canceled terminal interaction
+pub(super) async fn create_and_link_databases_for_existing_app(
+    interactor: &impl Interactor,
+    client: &impl CloudClientInterface,
+    app_name: &str,
+    app_id: Uuid,
+    labels: HashSet<String>,
+) -> anyhow::Result<Option<()>> {
+    for label in labels {
+        let resource_label = ResourceLabel {
+            app_id,
+            label,
+            app_name: Some(app_name.to_string()),
+        };
+        if let ExistingAppDatabaseSelection::NotYetLinked(selection) =
+            get_database_selection_for_existing_app(interactor, app_name, client, &resource_label)
+                .await?
+        {
+            match selection {
+                // User canceled terminal interaction
+                DatabaseSelection::Cancelled => return Ok(None),
+                DatabaseSelection::New(db) => {
+                    client.create_database(db, Some(resource_label)).await?;
+                }
+                DatabaseSelection::Existing(db) => {
+                    client
+                        .create_database_link(&db, resource_label)
+                        .await
+                        .with_context(|| {
+                            format!(r#"Could not link database "{}" to app "{}""#, db, app_name,)
+                        })?;
+                }
+            }
+        }
+    }
+    Ok(Some(()))
+}
+
+pub(super) async fn link_databases(
+    client: &impl CloudClientInterface,
+    app_name: &str,
+    app_id: Uuid,
+    database_labels: Vec<(String, String)>,
+) -> anyhow::Result<()> {
+    for (database, label) in database_labels {
+        let resource_label = ResourceLabel {
+            label,
+            app_id,
+            app_name: Some(app_name.to_owned()),
+        };
+        client
+            .create_database_link(&database, resource_label)
+            .await
+            .with_context(|| {
+                format!(
+                    r#"Failed to link database "{}" to app "{}""#,
+                    database, app_name
+                )
+            })?;
+    }
+    Ok(())
+}
+
+/// A user's selection of a database to link to a label
+enum DatabaseSelection {
+    Existing(String),
+    New(String),
+    Cancelled,
+}
+
+/// Whether a database has already been linked or not
+enum ExistingAppDatabaseSelection {
+    NotYetLinked(DatabaseSelection),
+    AlreadyLinked,
+}
+
+async fn get_database_selection_for_existing_app(
+    interactor: &impl Interactor,
+    name: &str,
+    client: &impl CloudClientInterface,
+    resource_label: &ResourceLabel,
+) -> Result<ExistingAppDatabaseSelection> {
+    let databases = client.get_databases(None).await?;
+    if databases
+        .iter()
+        .any(|d| database_has_link(d, &resource_label.label, resource_label.app_name.as_deref()))
+    {
+        return Ok(ExistingAppDatabaseSelection::AlreadyLinked);
+    }
+    let selection = prompt_database_selection(interactor, name, &resource_label.label, databases)?;
+    Ok(ExistingAppDatabaseSelection::NotYetLinked(selection))
+}
+
+async fn get_database_selection_for_new_app(
+    interactor: &impl Interactor,
+    name: &str,
+    client: &impl CloudClientInterface,
+    label: &str,
+) -> Result<DatabaseSelection> {
+    let databases = client.get_databases(None).await?;
+    prompt_database_selection(interactor, name, label, databases)
+}
+
+fn prompt_database_selection(
+    interactor: &impl Interactor,
+    name: &str,
+    label: &str,
+    databases: Vec<Database>,
+) -> Result<DatabaseSelection> {
+    let prompt = format!(
+        r#"App "{name}" accesses a database labeled "{label}"
+Would you like to link an existing database or create a new database?"#
+    );
+    let existing_opt = "Use an existing database and link app to it";
+    let create_opt = "Create a new database and link the app to it";
+    let opts = vec![existing_opt, create_opt];
+    let index = match interactor.select(&prompt, &opts, 1)? {
+        Some(i) => i,
+        None => return Ok(DatabaseSelection::Cancelled),
+    };
+    match index {
+        0 => prompt_for_existing_database(
+            interactor,
+            name,
+            label,
+            databases.into_iter().map(|d| d.name).collect::<Vec<_>>(),
+        ),
+        1 => prompt_link_to_new_database(
+            interactor,
+            name,
+            label,
+            databases
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect::<HashSet<_>>(),
+        ),
+        _ => bail!("Choose unavailable option"),
+    }
+}
+
+fn prompt_for_existing_database(
+    interactor: &impl Interactor,
+    name: &str,
+    label: &str,
+    mut database_names: Vec<String>,
+) -> Result<DatabaseSelection> {
+    let prompt =
+        format!(r#"Which database would you like to link to {name} using the label "{label}""#);
+    let index = match interactor.select(&prompt, &database_names, 0)? {
+        Some(i) => i,
+        None => return Ok(DatabaseSelection::Cancelled),
+    };
+    Ok(DatabaseSelection::Existing(database_names.remove(index)))
+}
+
+fn prompt_link_to_new_database(
+    interactor: &impl Interactor,
+    name: &str,
+    label: &str,
+    existing_names: HashSet<&str>,
+) -> Result<DatabaseSelection> {
+    let generator = RandomNameGenerator::new();
+    let default_name = generator
+        .generate_unique(existing_names, 20)
+        .context("could not generate unique database name")?;
+
+    let prompt = format!(
+        r#"What would you like to name your database?
+Note: This name is used when managing your database at the account level. The app "{name}" will refer to this database by the label "{label}".
+Other apps can use different labels to refer to the same database."#
+    );
+    let name = interactor.input(&prompt, &default_name)?;
+    Ok(DatabaseSelection::New(name))
+}

--- a/src/commands/deploy/interaction.rs
+++ b/src/commands/deploy/interaction.rs
@@ -1,0 +1,37 @@
+pub trait Interactor {
+    fn input(&self, prompt: &str, default_text: &str) -> std::io::Result<String>;
+    fn select<T: ToString>(
+        &self,
+        prompt: &str,
+        items: &[T],
+        default_index: usize,
+    ) -> std::io::Result<Option<usize>>;
+}
+
+pub fn interactive() -> impl Interactor {
+    Interactive
+}
+
+struct Interactive;
+
+impl Interactor for Interactive {
+    fn input(&self, prompt: &str, default_text: &str) -> std::io::Result<String> {
+        dialoguer::Input::new()
+            .with_prompt(prompt)
+            .default(default_text.to_string())
+            .interact_text()
+    }
+
+    fn select<T: ToString>(
+        &self,
+        prompt: &str,
+        items: &[T],
+        default_index: usize,
+    ) -> std::io::Result<Option<usize>> {
+        dialoguer::Select::new()
+            .with_prompt(prompt)
+            .items(items)
+            .default(default_index)
+            .interact_opt()
+    }
+}

--- a/src/commands/deploy/login.rs
+++ b/src/commands/deploy/login.rs
@@ -1,0 +1,171 @@
+use std::{
+    io::{self},
+    path::PathBuf,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use cloud::client::{Client as CloudClient, ConnectionConfig};
+use cloud::CloudClientInterface;
+use spin_common::sloth;
+use tokio::fs;
+use url::Url;
+
+use crate::commands::login::{LoginCommand, LoginConnection};
+
+pub async fn login_connection(deployment_env_id: Option<&str>) -> Result<LoginConnection> {
+    let path = config_file_path(deployment_env_id)?;
+
+    // log in if config.json does not exist or cannot be read
+    let data = match fs::read_to_string(path.clone()).await {
+        Ok(d) => d,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            match deployment_env_id {
+                Some(name) => {
+                    // TODO: allow auto redirect to login preserving the name
+                    eprintln!("You have no instance saved as '{}'", name);
+                    eprintln!("Run `spin login --environment-name {}` to log in", name);
+                    std::process::exit(1);
+                }
+                None => {
+                    // log in, then read config
+                    // TODO: propagate deployment id (or bail if nondefault?)
+                    LoginCommand::parse_from(vec!["login"]).run().await?;
+                    fs::read_to_string(path.clone()).await?
+                }
+            }
+        }
+        Err(e) => {
+            bail!("Could not log in: {}", e);
+        }
+    };
+
+    let mut login_connection: LoginConnection = serde_json::from_str(&data)?;
+    let expired = match has_expired(&login_connection) {
+        Ok(val) => val,
+        Err(err) => {
+            eprintln!("{}\n", err);
+            eprintln!("Run `spin login` to log in again");
+            std::process::exit(1);
+        }
+    };
+
+    if expired {
+        // if we have a refresh token available, let's try to refresh the token
+        match login_connection.refresh_token {
+            Some(refresh_token) => {
+                // Only Cloud has support for refresh tokens
+                let connection_config = ConnectionConfig {
+                    url: login_connection.url.to_string(),
+                    insecure: login_connection.danger_accept_invalid_certs,
+                    token: login_connection.token.clone(),
+                };
+                let client = CloudClient::new(connection_config.clone());
+
+                match client
+                    .refresh_token(login_connection.token, refresh_token)
+                    .await
+                {
+                    Ok(token_info) => {
+                        login_connection.token = token_info.token;
+                        login_connection.refresh_token = Some(token_info.refresh_token);
+                        login_connection.expiration = Some(token_info.expiration);
+                        // save new token info
+                        let path = config_file_path(deployment_env_id)?;
+                        std::fs::write(path, serde_json::to_string_pretty(&login_connection)?)?;
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to refresh token: {}", e);
+                        match deployment_env_id {
+                            Some(name) => {
+                                eprintln!(
+                                    "Run `spin login --environment-name {}` to log in again",
+                                    name
+                                );
+                            }
+                            None => {
+                                eprintln!("Run `spin login` to log in again");
+                            }
+                        }
+                        std::process::exit(1);
+                    }
+                }
+            }
+            None => {
+                // session has expired and we have no way to refresh the token - log back in
+                match deployment_env_id {
+                    Some(name) => {
+                        // TODO: allow auto redirect to login preserving the name
+                        eprintln!("Your login to this environment has expired");
+                        eprintln!(
+                            "Run `spin login --environment-name {}` to log in again",
+                            name
+                        );
+                        std::process::exit(1);
+                    }
+                    None => {
+                        LoginCommand::parse_from(vec!["login"]).run().await?;
+                        let new_data = fs::read_to_string(path.clone()).await.context(format!(
+                            "Cannot find spin config at {}",
+                            path.to_string_lossy()
+                        ))?;
+                        login_connection = serde_json::from_str(&new_data)?;
+                    }
+                }
+            }
+        }
+    }
+
+    let sloth_guard = sloth::warn_if_slothful(
+        2500,
+        format!("Checking status ({})\n", login_connection.url),
+    );
+    check_healthz(&login_connection.url).await?;
+    // Server has responded - we don't want to keep the sloth timer running.
+    drop(sloth_guard);
+
+    Ok(login_connection)
+}
+
+// TODO: unify with login
+fn config_file_path(deployment_env_id: Option<&str>) -> Result<PathBuf> {
+    let root = dirs::config_dir()
+        .context("Cannot find configuration directory")?
+        .join("fermyon");
+
+    let file_stem = match deployment_env_id {
+        None => "config",
+        Some(id) => id,
+    };
+    let file = format!("{}.json", file_stem);
+
+    let path = root.join(file);
+
+    Ok(path)
+}
+
+// Check if the token has expired.
+// If the expiration is None, assume the token has not expired
+fn has_expired(login_connection: &LoginConnection) -> Result<bool> {
+    match &login_connection.expiration {
+        Some(expiration) => match DateTime::parse_from_rfc3339(expiration) {
+            Ok(time) => Ok(Utc::now() > time),
+            Err(err) => Err(anyhow!(
+                "Failed to parse token expiration time '{}'. Error: {}",
+                expiration,
+                err
+            )),
+        },
+        None => Ok(false),
+    }
+}
+
+async fn check_healthz(base_url: &Url) -> Result<()> {
+    let healthz_url = base_url.join("healthz")?;
+    reqwest::get(healthz_url)
+        .await?
+        .error_for_status()
+        .with_context(|| format!("Server {} is unhealthy", base_url))?;
+    Ok(())
+}


### PR DESCRIPTION
This is (or at least should be) a pure refactoring.  The key changes are:

* Move blocks of related functions out of the main `deploy.rs` file into their own modules, and make only the required entry points public.  This reduces the size of the main file, and enables readers to identify the 'surface' operations without searching through the ancillary ones.
* Break out some large blocks of code into their own functions.  This reduces the size of the main function, to enables readers to read the function without needing to keep conditions on their mental stack across dozens of lines.  (Although the function calls are still vexingly long; maybe I'm still missing a struct or enum to bring these into focus.  Or maybe it's `cargo fmt`'s fault.  That guy is always causing trouble!)
* Move (certain) I/O operations onto interfaces.  Deployment now uses the CloudClientInterface throughout (which required a small change to unrelated variables code, sorry), and I introduced a new Interactor trait to enable substitution of command line prompting.  The latter is, I am sure, at the wrong level of abstraction right now; the right level would enable both mocking _and_ a scripted-answers implementation for CI/non-interactive deployments.
