### PR TITLE
chore(Cargo.toml): bump spin crates to v1.6 branch revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -157,6 +157,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0c4a4f319e45986f347ee47fef8bf5e81c9abc3f6f58dc2391439f30df65f0"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.25",
+ "slab",
+ "socket2 0.4.9",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.0.0",
+ "futures-lite",
+ "rustix 0.38.19",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a5415b7abcdc9cd7d63d6badba5288b2ca017e3fbd4173b8f405449f1a2399"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.19",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +299,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tar"
+version = "0.4.2"
+source = "git+https://github.com/vdice/async-tar?rev=71e037f9652971e7a55b412a8e47a37b06f9c29d#71e037f9652971e7a55b412a8e47a37b06f9c29d"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall 0.2.16",
+ "xattr 0.2.3",
+]
+
+[[package]]
+name = "async-task"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +327,12 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -417,6 +562,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -1494,6 +1655,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +2003,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -2332,6 +2516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2760,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -3112,7 +3308,7 @@ dependencies = [
 [[package]]
 name = "outbound-http"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "http",
@@ -3127,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "outbound-mysql"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "flate2",
@@ -3143,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "outbound-pg"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -3158,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "outbound-redis"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "redis",
@@ -3378,10 +3574,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "postgres-native-tls"
@@ -4428,7 +4651,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "spin-app"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4443,7 +4666,7 @@ dependencies = [
 [[package]]
 name = "spin-common"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -4466,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "spin-config"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "spin-core"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4504,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "spin-http"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "http",
@@ -4519,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -4533,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-azure"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "azure_data_cosmos",
@@ -4548,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-redis"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "redis",
@@ -4562,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -4576,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "spin-llm"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4589,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "spin-llm-remote-http"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "http",
@@ -4605,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "spin-loader"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4641,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "spin-manifest"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "indexmap 1.9.3",
  "serde",
@@ -4652,9 +4875,11 @@ dependencies = [
 [[package]]
 name = "spin-oci"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
+ "async-compression 0.4.4",
+ "async-tar",
  "base64 0.21.4",
  "dirs 4.0.0",
  "dkregistry",
@@ -4665,11 +4890,13 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-app",
+ "spin-common",
  "spin-loader",
  "spin-manifest",
  "spin-trigger",
  "tempfile",
  "tokio",
+ "tokio-util 0.7.9",
  "tracing",
  "walkdir",
 ]
@@ -4677,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "spin-sqlite"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4691,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "spin-sqlite-inproc"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4706,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "spin-sqlite-libsql"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4721,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "spin-trigger"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4765,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "spin-trigger-http"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4798,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "spin-world"
 version = "1.6.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "wasmtime",
 ]
@@ -5017,7 +5244,7 @@ checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
+ "xattr 1.0.1",
 ]
 
 [[package]]
@@ -5051,7 +5278,7 @@ dependencies = [
 [[package]]
 name = "terminal"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=0306346e554a8ae2968861ee85d4c6fb6b336e8b#0306346e554a8ae2968861ee85d4c6fb6b336e8b"
+source = "git+https://github.com/fermyon/spin?rev=54c4d83987f0519ef885b532d577845443d4d61b#54c4d83987f0519ef885b532d577845443d4d61b"
 dependencies = [
  "atty",
  "once_cell",
@@ -5294,7 +5521,7 @@ dependencies = [
  "redox_syscall 0.3.5",
  "tokio",
  "tokio-stream",
- "xattr",
+ "xattr 1.0.1",
 ]
 
 [[package]]
@@ -5511,6 +5738,12 @@ dependencies = [
  "getrandom 0.2.10",
  "serde",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
 
 [[package]]
 name = "vaultrs"
@@ -6528,6 +6761,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,15 +32,15 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 sha2 = "0.10.2"
-spin-app = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-common = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-loader = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-manifest = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-http = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-oci = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-trigger = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
-terminal = { git = "https://github.com/fermyon/spin", rev = "0306346e554a8ae2968861ee85d4c6fb6b336e8b" }
+spin-app = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-common = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-loader = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-manifest = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-http = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-oci = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-trigger = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
+terminal = { git = "https://github.com/fermyon/spin", rev = "54c4d83987f0519ef885b532d577845443d4d61b" }
 tempfile = "3.3.0"
 url = "2.3"
 uuid = { version = "1.3", features = ["v4"] }


### PR DESCRIPTION
Bump spin crates to https://github.com/fermyon/spin/commit/54c4d83987f0519ef885b532d577845443d4d61b to get fix for https://github.com/fermyon/spin/issues/1787 and related commits.

Full diff: https://github.com/fermyon/spin/compare/0306346...54c4d83