### PR TITLE
chore(Cargo.toml): bump to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cloud-openapi",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Version bump to 0.4.1 after https://github.com/fermyon/cloud-plugin/pull/136 is in.

Diff: https://github.com/fermyon/cloud-plugin/compare/v0.4.0...v0.4

~~Depends on https://github.com/fermyon/cloud-plugin/pull/136 (will rebase afterwards)~~ done