### PR TITLE
chore(spin-pluginify.toml): bump to 0.4.1

### DIFF
--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "cloud"
 description = "Commands for publishing applications to the Fermyon Cloud."
-version = "0.4.0"
+version = "0.4.1"
 spin_compatibility = ">=1.3"
 license = "Apache-2.0"
 homepage = "https://github.com/fermyon/cloud-plugin"


### PR DESCRIPTION
Missed in https://github.com/fermyon/cloud-plugin/pull/137