### PR TITLE
`spin cloud deploy`: Drop calls to create/update channel

### DIFF
--- a/crates/cloud/src/client_interface.rs
+++ b/crates/cloud/src/client_interface.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use cloud_openapi::models::{
-    AppItem, AppItemPage, ChannelItem, ChannelItemPage, ChannelRevisionSelectionStrategy, Database,
-    DeviceCodeItem, EnvironmentVariableItem, GetAppLogsVm, GetAppRawLogsVm, ResourceLabel,
+    AppItem, AppItemPage, Database, DeviceCodeItem, GetAppLogsVm, GetAppRawLogsVm, ResourceLabel,
     RevisionItemPage, TokenInfo,
 };
 
@@ -34,33 +33,6 @@ pub trait CloudClientInterface: Send + Sync {
         max_lines: Option<i32>,
         since: Option<String>,
     ) -> Result<GetAppRawLogsVm>;
-
-    async fn get_channel_by_id(&self, id: &str) -> Result<ChannelItem>;
-
-    async fn list_channels(&self) -> Result<ChannelItemPage>;
-
-    async fn list_channels_next(&self, previous: &ChannelItemPage) -> Result<ChannelItemPage>;
-
-    async fn add_channel(
-        &self,
-        app_id: Uuid,
-        name: String,
-        revision_selection_strategy: ChannelRevisionSelectionStrategy,
-        range_rule: Option<String>,
-        active_revision_id: Option<Uuid>,
-    ) -> anyhow::Result<Uuid>;
-
-    async fn patch_channel(
-        &self,
-        id: Uuid,
-        name: Option<String>,
-        revision_selection_strategy: Option<ChannelRevisionSelectionStrategy>,
-        range_rule: Option<String>,
-        active_revision_id: Option<Uuid>,
-        environment_variables: Option<Vec<EnvironmentVariableItem>>,
-    ) -> anyhow::Result<()>;
-
-    async fn remove_channel(&self, id: String) -> Result<()>;
 
     async fn add_revision(
         &self,

--- a/crates/cloud/src/cloud_client_extensions.rs
+++ b/crates/cloud/src/cloud_client_extensions.rs
@@ -8,7 +8,6 @@ use crate::CloudClientInterface;
 pub trait CloudClientExt {
     async fn get_app_id(&self, app_name: &str) -> Result<Option<Uuid>>;
     async fn get_revision_id(&self, app_id: Uuid, version: &str) -> Result<Uuid>;
-    async fn get_channel_id(&self, app_id: Uuid, channel_name: &str) -> Result<Uuid>;
 }
 
 #[async_trait]
@@ -45,32 +44,6 @@ impl<T: CloudClientInterface> CloudClientExt for T {
             "No revision with version {} and app id {}",
             version,
             app_id
-        ))
-    }
-
-    async fn get_channel_id(&self, app_id: Uuid, channel_name: &str) -> Result<Uuid> {
-        let mut channels_vm = self.list_channels().await?;
-
-        loop {
-            if let Some(channel) = channels_vm
-                .items
-                .iter()
-                .find(|&x| x.app_id == app_id && x.name == channel_name)
-            {
-                return Ok(channel.id);
-            }
-
-            if channels_vm.is_last_page {
-                break;
-            }
-
-            channels_vm = self.list_channels_next(&channels_vm).await?;
-        }
-
-        Err(anyhow!(
-            "No channel with app_id {} and name {}",
-            app_id,
-            channel_name,
         ))
     }
 }


### PR DESCRIPTION
New updates to the Fermyon Cloud API made the calls to `POST /api/channels` and `PATCH /api/channels` redundant as the active revision is calculated based on the app's list of revisions. A client now only has to call `create_app` followed by `add_revision` to trigger a deploy to production. On follow-up deploys, only a call to `add_revision` is necessary.