### PR TITLE
Update to latest Spin crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "spin-manifest",
  "spin-oci",
  "tempfile",
- "terminal 0.1.0 (git+https://github.com/fermyon/spin?rev=57b004cf7fa2b6ad545bd8292f2745ed6424f05b)",
+ "terminal",
  "tokio",
  "tracing",
  "url",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1403,9 +1403,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1630,10 +1630,10 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.10.0"
-source = "git+https://github.com/fermyon/oci-distribution?rev=05022618d78feef9b99f20b5da8fd6def6bb80d2#05022618d78feef9b99f20b5da8fd6def6bb80d2"
+source = "git+https://github.com/fermyon/oci-distribution?rev=63cbb0925775e0c9c870195cad1d50ac8707a264#63cbb0925775e0c9c870195cad1d50ac8707a264"
 dependencies = [
+ "bytes",
  "chrono",
- "futures",
  "futures-util",
  "http",
  "http-auth",
@@ -1647,7 +1647,6 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
  "tracing",
  "unicase",
 ]
@@ -1671,9 +1670,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1703,9 +1702,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
 dependencies = [
  "cc",
  "libc",
@@ -1752,14 +1751,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "http",
  "reqwest",
  "spin-locked-app",
- "terminal 0.1.0 (git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6)",
+ "spin-outbound-networking",
+ "terminal",
  "tracing",
  "url",
 ]
@@ -2405,8 +2405,8 @@ dependencies = [
 
 [[package]]
 name = "spin-common"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -2418,8 +2418,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "http",
@@ -2434,8 +2434,8 @@ dependencies = [
 
 [[package]]
 name = "spin-loader"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
  "spin-manifest",
  "spin-outbound-networking",
  "tempfile",
- "terminal 0.1.0 (git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6)",
+ "terminal",
  "thiserror",
  "tokio",
  "tokio-util 0.6.10",
@@ -2472,8 +2472,8 @@ dependencies = [
 
 [[package]]
 name = "spin-locked-app"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2486,21 +2486,23 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
  "serde",
  "spin-serde",
+ "terminal",
  "thiserror",
  "toml",
+ "url",
 ]
 
 [[package]]
 name = "spin-oci"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2527,19 +2529,19 @@ dependencies = [
 
 [[package]]
 name = "spin-outbound-networking"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "anyhow",
  "spin-locked-app",
- "terminal 0.1.0 (git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6)",
+ "terminal",
  "url",
 ]
 
 [[package]]
 name = "spin-serde"
-version = "2.0.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
+version = "2.0.0-rc.1"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -2680,17 +2682,7 @@ dependencies = [
 [[package]]
 name = "terminal"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=561b3e132b99537d823b33984e371bb8326ad3e6#561b3e132b99537d823b33984e371bb8326ad3e6"
-dependencies = [
- "atty",
- "once_cell",
- "termcolor",
-]
-
-[[package]]
-name = "terminal"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=57b004cf7fa2b6ad545bd8292f2745ed6424f05b#57b004cf7fa2b6ad545bd8292f2745ed6424f05b"
+source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
 dependencies = [
  "atty",
  "once_cell",
@@ -2850,7 +2842,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2872,7 +2864,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3055,9 +3047,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3065,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -3080,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3092,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3102,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3115,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-streams"
@@ -3134,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ comfy-table = "7"
 dirs = "5.0"
 dialoguer = "0.10"
 lazy_static = "1.4.0"
-oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "05022618d78feef9b99f20b5da8fd6def6bb80d2" }
+oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "63cbb0925775e0c9c870195cad1d50ac8707a264" }
 tokio = { version = "1.23", features = ["full"] }
 tracing = { workspace = true }
 rand = "0.8"
@@ -32,13 +32,13 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 sha2 = "0.10.2"
-spin-common = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6" }
-spin-loader = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6" }
-spin-locked-app = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6" }
-spin-http = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6", default-features = false }
-spin-manifest = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6" }
-spin-oci = { git = "https://github.com/fermyon/spin", rev = "561b3e132b99537d823b33984e371bb8326ad3e6" }
-terminal = { git = "https://github.com/fermyon/spin", rev = "57b004cf7fa2b6ad545bd8292f2745ed6424f05b" }
+spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+spin-locked-app = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+spin-http = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1", default-features = false }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+terminal = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
 tempfile = "3.3.0"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4"] }


### PR DESCRIPTION
This updates the Spin crate references to a near-2.0 commit.  This is needed so that deploy can process the latest Manifest 2 changes, specifically `allowed_outbound_hosts`.

Because the latest Spin crates change the OCI format, **this cannot merge until the associated Cloud PR merges** or apps will appear to deploy but never go live.  This is in progress with @vdice.  Once that happens I will test and merge this.
