### PR TITLE
chore(Cargo.toml): bump spin crates to latest v2.0 branch revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "outbound-http"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "http",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "spin-common"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "spin-http"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "http",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "spin-loader"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "spin-locked-app"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "spin-manifest"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -2502,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "spin-oci"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "spin-outbound-networking"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "anyhow",
  "spin-locked-app",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "spin-serde"
 version = "2.0.0-rc.1"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "terminal"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.0.0-rc.1#2cb5b1fe27b16b860f4b66184d47b77b27bc1dee"
+source = "git+https://github.com/fermyon/spin?rev=d816b512cc541138d489fcbd29ec535b9958f31e#d816b512cc541138d489fcbd29ec535b9958f31e"
 dependencies = [
  "atty",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,13 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"
 sha2 = "0.10.2"
-spin-common = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
-spin-locked-app = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
-spin-http = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1", default-features = false }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
-spin-oci = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
-terminal = { git = "https://github.com/fermyon/spin", tag = "v2.0.0-rc.1" }
+spin-common = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
+spin-loader = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
+spin-locked-app = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
+spin-http = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e", default-features = false }
+spin-manifest = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
+spin-oci = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
+terminal = { git = "https://github.com/fermyon/spin", rev = "d816b512cc541138d489fcbd29ec535b9958f31e" }
 tempfile = "3.3.0"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4"] }


### PR DESCRIPTION
Revs to https://github.com/fermyon/spin/commit/d816b512cc541138d489fcbd29ec535b9958f31e