### PR TITLE
chore(*): bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "cloud"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "cloud"
 description = "Commands for publishing applications to the Fermyon Cloud."
-version = "0.5.0"
+version = "0.5.1"
 spin_compatibility = ">=1.3"
 license = "Apache-2.0"
 homepage = "https://github.com/fermyon/cloud-plugin"


### PR DESCRIPTION
Diff is: https://github.com/fermyon/cloud-plugin/compare/v0.5.0...main