### PR TITLE
Non interactive databases take two

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -6,8 +6,7 @@ use cloud::{
     CloudClientExt, CloudClientInterface,
 };
 use cloud_openapi::models::{
-    ChannelRevisionSelectionStrategy as CloudChannelRevisionSelectionStrategy, Database,
-    ResourceLabel,
+    ChannelRevisionSelectionStrategy as CloudChannelRevisionSelectionStrategy,
 };
 use oci_distribution::{token_cache, Reference, RegistryOperation};
 use spin_common::arg_parser::parse_kv;
@@ -22,14 +21,12 @@ use std::{
     path::{Path, PathBuf},
 };
 use url::Url;
-use uuid::Uuid;
 
 use crate::{
     commands::{
         variables::{get_variables, set_variables},
         DEFAULT_CLOUD_URL,
     },
-    random_name::RandomNameGenerator,
     spin,
 };
 
@@ -38,7 +35,9 @@ use crate::{
     opts::*,
 };
 
-use super::sqlite::database_has_link;
+mod database;
+
+use database::{create_and_link_databases_for_existing_app, create_databases_for_new_app, link_databases};
 
 const SPIN_DEPLOY_CHANNEL_NAME: &str = "spin-deploy";
 pub const DEVELOPER_CLOUD_FAQ: &str = "https://developer.fermyon.com/cloud/faq";
@@ -577,211 +576,6 @@ fn validate_cloud_app(app: &DeployableApp) -> Result<()> {
         {
             bail!("Invalid store {invalid_store:?} for component {:?}. Cloud currently supports only the 'default' store.", component.id());
         }
-    }
-    Ok(())
-}
-
-/// A user's selection of a database to link to a label
-enum DatabaseSelection {
-    Existing(String),
-    New(String),
-    Cancelled,
-}
-
-/// Whether a database has already been linked or not
-enum ExistingAppDatabaseSelection {
-    NotYetLinked(DatabaseSelection),
-    AlreadyLinked,
-}
-
-async fn get_database_selection_for_existing_app(
-    name: &str,
-    client: &CloudClient,
-    resource_label: &ResourceLabel,
-) -> Result<ExistingAppDatabaseSelection> {
-    let databases = client.get_databases(None).await?;
-    if databases
-        .iter()
-        .any(|d| database_has_link(d, &resource_label.label, resource_label.app_name.as_deref()))
-    {
-        return Ok(ExistingAppDatabaseSelection::AlreadyLinked);
-    }
-    let selection = prompt_database_selection(name, &resource_label.label, databases)?;
-    Ok(ExistingAppDatabaseSelection::NotYetLinked(selection))
-}
-
-async fn get_database_selection_for_new_app(
-    name: &str,
-    client: &CloudClient,
-    label: &str,
-) -> Result<DatabaseSelection> {
-    let databases = client.get_databases(None).await?;
-    prompt_database_selection(name, label, databases)
-}
-
-fn prompt_database_selection(
-    name: &str,
-    label: &str,
-    databases: Vec<Database>,
-) -> Result<DatabaseSelection> {
-    let prompt = format!(
-        r#"App "{name}" accesses a database labeled "{label}"
-Would you like to link an existing database or create a new database?"#
-    );
-    let existing_opt = "Use an existing database and link app to it";
-    let create_opt = "Create a new database and link the app to it";
-    let opts = vec![existing_opt, create_opt];
-    let index = match dialoguer::Select::new()
-        .with_prompt(prompt)
-        .items(&opts)
-        .default(1)
-        .interact_opt()?
-    {
-        Some(i) => i,
-        None => return Ok(DatabaseSelection::Cancelled),
-    };
-    match index {
-        0 => prompt_for_existing_database(
-            name,
-            label,
-            databases.into_iter().map(|d| d.name).collect::<Vec<_>>(),
-        ),
-        1 => prompt_link_to_new_database(
-            name,
-            label,
-            databases
-                .iter()
-                .map(|d| d.name.as_str())
-                .collect::<HashSet<_>>(),
-        ),
-        _ => bail!("Choose unavailable option"),
-    }
-}
-
-fn prompt_for_existing_database(
-    name: &str,
-    label: &str,
-    mut database_names: Vec<String>,
-) -> Result<DatabaseSelection> {
-    let prompt =
-        format!(r#"Which database would you like to link to {name} using the label "{label}""#);
-    let index = match dialoguer::Select::new()
-        .with_prompt(prompt)
-        .items(&database_names)
-        .default(0)
-        .interact_opt()?
-    {
-        Some(i) => i,
-        None => return Ok(DatabaseSelection::Cancelled),
-    };
-    Ok(DatabaseSelection::Existing(database_names.remove(index)))
-}
-
-fn prompt_link_to_new_database(
-    name: &str,
-    label: &str,
-    existing_names: HashSet<&str>,
-) -> Result<DatabaseSelection> {
-    let generator = RandomNameGenerator::new();
-    let default_name = generator
-        .generate_unique(existing_names, 20)
-        .context("could not generate unique database name")?;
-
-    let prompt = format!(
-        r#"What would you like to name your database?
-Note: This name is used when managing your database at the account level. The app "{name}" will refer to this database by the label "{label}".
-Other apps can use different labels to refer to the same database."#
-    );
-    let name = dialoguer::Input::new()
-        .with_prompt(prompt)
-        .default(default_name)
-        .interact_text()?;
-    Ok(DatabaseSelection::New(name))
-}
-
-// Loops through an app's manifest and creates databases.
-// Returns a list of database and label pairs that should be
-// linked to the app once it is created.
-// Returns None if the user canceled terminal interaction
-async fn create_databases_for_new_app(
-    client: &CloudClient,
-    name: &str,
-    labels: HashSet<String>,
-) -> anyhow::Result<Option<Vec<(String, String)>>> {
-    let mut databases_to_link = Vec::new();
-    for label in labels {
-        let db = match get_database_selection_for_new_app(name, client, &label).await? {
-            DatabaseSelection::Existing(db) => db,
-            DatabaseSelection::New(db) => {
-                client.create_database(db.clone(), None).await?;
-                db
-            }
-            // User canceled terminal interaction
-            DatabaseSelection::Cancelled => return Ok(None),
-        };
-        databases_to_link.push((db, label));
-    }
-    Ok(Some(databases_to_link))
-}
-
-// Loops through an updated app's manifest and creates and links any newly referenced databases.
-// Returns None if the user canceled terminal interaction
-async fn create_and_link_databases_for_existing_app(
-    client: &CloudClient,
-    app_name: &str,
-    app_id: Uuid,
-    labels: HashSet<String>,
-) -> anyhow::Result<Option<()>> {
-    for label in labels {
-        let resource_label = ResourceLabel {
-            app_id,
-            label,
-            app_name: Some(app_name.to_string()),
-        };
-        if let ExistingAppDatabaseSelection::NotYetLinked(selection) =
-            get_database_selection_for_existing_app(app_name, client, &resource_label).await?
-        {
-            match selection {
-                // User canceled terminal interaction
-                DatabaseSelection::Cancelled => return Ok(None),
-                DatabaseSelection::New(db) => {
-                    client.create_database(db, Some(resource_label)).await?;
-                }
-                DatabaseSelection::Existing(db) => {
-                    client
-                        .create_database_link(&db, resource_label)
-                        .await
-                        .with_context(|| {
-                            format!(r#"Could not link database "{}" to app "{}""#, db, app_name,)
-                        })?;
-                }
-            }
-        }
-    }
-    Ok(Some(()))
-}
-
-async fn link_databases(
-    client: &CloudClient,
-    app_name: &str,
-    app_id: Uuid,
-    database_labels: Vec<(String, String)>,
-) -> anyhow::Result<()> {
-    for (database, label) in database_labels {
-        let resource_label = ResourceLabel {
-            label,
-            app_id,
-            app_name: Some(app_name.to_owned()),
-        };
-        client
-            .create_database_link(&database, resource_label)
-            .await
-            .with_context(|| {
-                format!(
-                    r#"Failed to link database "{}" to app "{}""#,
-                    database, app_name
-                )
-            })?;
     }
     Ok(())
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -172,6 +172,7 @@ impl DeployCommand {
         };
 
         let client = CloudClient::new(connection_config.clone());
+        let interact = database::Interactive;
 
         let dir = tempfile::tempdir()?;
 
@@ -196,7 +197,7 @@ impl DeployCommand {
             Some(app_id) => {
                 let labels = application.sqlite_databases();
                 if !labels.is_empty()
-                    && create_and_link_databases_for_existing_app(&client, &name, app_id, labels)
+                    && create_and_link_databases_for_existing_app(&client, &name, app_id, labels, &interact)
                         .await?
                         .is_none()
                 {
@@ -236,7 +237,7 @@ impl DeployCommand {
             None => {
                 let labels = application.sqlite_databases();
                 let databases_to_link =
-                    match create_databases_for_new_app(&client, &name, labels).await? {
+                    match create_databases_for_new_app(&client, &name, labels, &interact).await? {
                         Some(dbs) => dbs,
                         None => return Ok(()), // User canceled terminal interaction
                     };

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -5,9 +5,7 @@ use cloud::{
     client::{Client as CloudClient, ConnectionConfig},
     CloudClientExt, CloudClientInterface,
 };
-use cloud_openapi::models::{
-    ChannelRevisionSelectionStrategy as CloudChannelRevisionSelectionStrategy,
-};
+use cloud_openapi::models::ChannelRevisionSelectionStrategy as CloudChannelRevisionSelectionStrategy;
 use oci_distribution::{token_cache, Reference, RegistryOperation};
 use spin_common::arg_parser::parse_kv;
 use spin_http::{app_info::AppInfo, routes::RoutePattern};
@@ -37,7 +35,9 @@ use crate::{
 
 mod database;
 
-use database::{create_and_link_databases_for_existing_app, create_databases_for_new_app, link_databases};
+use database::{
+    create_and_link_databases_for_existing_app, create_databases_for_new_app, link_databases,
+};
 
 const SPIN_DEPLOY_CHANNEL_NAME: &str = "spin-deploy";
 pub const DEVELOPER_CLOUD_FAQ: &str = "https://developer.fermyon.com/cloud/faq";
@@ -112,6 +112,20 @@ pub struct DeployCommand {
     /// Can be used multiple times.
     #[clap(long = "variable", parse(try_from_str = parse_kv))]
     pub variables: Vec<(String, String)>,
+
+    /// Specifies how application labels (such as SQLite databases) should
+    /// be linked if they are not already linked. This is intended for
+    /// non-interactive environments such as release pipelines; therefore,
+    /// if any links are specified, all links must be specified.
+    ///
+    /// Links must be of the form 'sqlite:label=database'. Databases that
+    /// do not exist will be created. To express "create a new database with
+    /// a random name", use the special database '*'. To link all labels
+    /// not specified in other --link flags, use the special label '*'.
+    /// Thus, 'sqlite:*=*' would create a new randomly named database for
+    /// every label that is not already linked.
+    #[clap(long = "link")]
+    pub links: Vec<String>,
 }
 
 impl DeployCommand {
@@ -172,7 +186,7 @@ impl DeployCommand {
         };
 
         let client = CloudClient::new(connection_config.clone());
-        let interact = database::Interactive;
+        let interact = self.interaction_strategy()?;
 
         let dir = tempfile::tempdir()?;
 
@@ -197,9 +211,15 @@ impl DeployCommand {
             Some(app_id) => {
                 let labels = application.sqlite_databases();
                 if !labels.is_empty()
-                    && create_and_link_databases_for_existing_app(&client, &name, app_id, labels, &interact)
-                        .await?
-                        .is_none()
+                    && create_and_link_databases_for_existing_app(
+                        &client,
+                        &name,
+                        app_id,
+                        labels,
+                        interact.as_ref(),
+                    )
+                    .await?
+                    .is_none()
                 {
                     // User canceled terminal interaction
                     return Ok(());
@@ -237,7 +257,9 @@ impl DeployCommand {
             None => {
                 let labels = application.sqlite_databases();
                 let databases_to_link =
-                    match create_databases_for_new_app(&client, &name, labels, &interact).await? {
+                    match create_databases_for_new_app(&client, &name, labels, interact.as_ref())
+                        .await?
+                    {
                         Some(dbs) => dbs,
                         None => return Ok(()), // User canceled terminal interaction
                     };
@@ -301,6 +323,15 @@ impl DeployCommand {
         }
 
         Ok(())
+    }
+
+    fn interaction_strategy(&self) -> anyhow::Result<Box<dyn database::InteractionStrategy>> {
+        if self.links.is_empty() {
+            return Ok(Box::new(database::Interactive));
+        }
+
+        let script = parse_linkage_specs(&self.links)?;
+        Ok(Box::new(script))
     }
 
     async fn load_cloud_app(&self, working_dir: &Path) -> Result<DeployableApp, anyhow::Error> {
@@ -969,6 +1000,56 @@ pub fn config_file_path(deployment_env_id: Option<&str>) -> Result<PathBuf> {
     Ok(path)
 }
 
+fn parse_linkage_specs(links: &[impl AsRef<str>]) -> anyhow::Result<database::Scripted> {
+    // TODO: would this be nicer as a fold?
+    let mut strategy = database::Scripted::default();
+
+    for link in links.iter().map(|s| parse_one_linkage_spec(s.as_ref())) {
+        match link? {
+            LinkageSpec::SqliteDefault { default } => strategy.set_default_db(default)?,
+            LinkageSpec::SqliteLabel { label, name } => strategy.set_label_action(&label, name)?,
+        };
+    }
+
+    Ok(strategy)
+}
+
+fn parse_one_linkage_spec(link: &str) -> anyhow::Result<LinkageSpec> {
+    let Some(spec) = link.strip_prefix("sqlite:") else {
+        bail!("Links must be of the form 'sqlite:label=database' ('*' allowed, see help)");
+    };
+    let Some((label, db)) = spec.split_once('=') else {
+        bail!("Links must be of the form 'sqlite:label=database' ('*' allowed, see help)");
+    };
+    let label = label.trim();
+    let db = db.trim();
+
+    let dbref = if db == "*" {
+        database::DatabaseRef::GenerateNew
+    } else {
+        database::DatabaseRef::Named(db.to_owned())
+    };
+
+    if label == "*" {
+        Ok(LinkageSpec::SqliteDefault { default: dbref })
+    } else {
+        Ok(LinkageSpec::SqliteLabel {
+            label: label.to_owned(),
+            name: dbref,
+        })
+    }
+}
+
+enum LinkageSpec {
+    SqliteLabel {
+        label: String,
+        name: database::DatabaseRef,
+    },
+    SqliteDefault {
+        default: database::DatabaseRef,
+    },
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1023,6 +1104,7 @@ mod test {
             deployment_env_id: None,
             key_values: vec![],
             variables: vec![],
+            links: vec![],
         }
     }
 
@@ -1079,5 +1161,67 @@ mod test {
         let app = cmd.load_cloud_app(temp_dir.path()).await.unwrap();
         let version = app.0.metadata.get("cloud_plugin_version").unwrap();
         assert_eq!(crate::VERSION, version);
+    }
+
+    fn string_set(strs: &[&str]) -> HashSet<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn new_app_databases_are_created_and_linked() {
+        let labels = string_set(&["default", "finance"]);
+        let links = ["sqlite:default=*", "sqlite:finance=excel"];
+        let linkages = parse_linkage_specs(&links).unwrap();
+
+        let mut client = cloud::MockCloudClientInterface::new();
+        let created_name_cell: std::sync::Arc<std::sync::RwLock<String>> =
+            std::sync::Arc::new(std::sync::RwLock::new("".to_owned()));
+        let created_name_c2 = created_name_cell.clone();
+
+        client.expect_get_databases().returning(|_| Ok(vec![]));
+        client
+            .expect_create_database()
+            .withf(|db, rlabel| db.contains('-') && rlabel.is_none())
+            .returning(move |db, _| {
+                *created_name_c2.write().unwrap() = db.to_string();
+                Ok(())
+            });
+        client.expect_get_databases().returning(|_| Ok(vec![]));
+        client
+            .expect_create_database()
+            .withf(|db, rlabel| db == "excel" && rlabel.is_none())
+            .returning(|_, _| Ok(()));
+
+        let databases_to_link = database::create_databases_for_new_app(
+            &client,
+            "test:script-new-app",
+            labels,
+            &linkages,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(2, databases_to_link.len());
+
+        client
+            .expect_create_database_link()
+            .withf(move |db, rlabel| {
+                let expected_name = created_name_cell.read().unwrap();
+                db == *expected_name && rlabel.label == "default"
+            })
+            .returning(|_, _| Ok(()));
+        client
+            .expect_create_database_link()
+            .withf(|db, rlabel| db == "excel" && rlabel.label == "finance")
+            .returning(|_, _| Ok(()));
+
+        database::link_databases(
+            &client,
+            "test:script-new-app",
+            uuid::Uuid::new_v4(),
+            databases_to_link,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/commands/deploy/database.rs
+++ b/src/commands/deploy/database.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context, Result};
 use cloud::{
-    client::{Client as CloudClient},
     CloudClientInterface,
 };
 use cloud_openapi::models::{
@@ -34,7 +33,7 @@ enum ExistingAppDatabaseSelection {
 
 async fn get_database_selection_for_existing_app(
     name: &str,
-    client: &CloudClient,
+    client: &impl CloudClientInterface,
     resource_label: &ResourceLabel,
 ) -> Result<ExistingAppDatabaseSelection> {
     let databases = client.get_databases(None).await?;
@@ -50,7 +49,7 @@ async fn get_database_selection_for_existing_app(
 
 async fn get_database_selection_for_new_app(
     name: &str,
-    client: &CloudClient,
+    client: &impl CloudClientInterface,
     label: &str,
 ) -> Result<DatabaseSelection> {
     let databases = client.get_databases(None).await?;
@@ -142,7 +141,7 @@ Other apps can use different labels to refer to the same database."#
 // linked to the app once it is created.
 // Returns None if the user canceled terminal interaction
 pub(super) async fn create_databases_for_new_app(
-    client: &CloudClient,
+    client: &impl CloudClientInterface,
     name: &str,
     labels: HashSet<String>,
 ) -> anyhow::Result<Option<Vec<(String, String)>>> {
@@ -165,7 +164,7 @@ pub(super) async fn create_databases_for_new_app(
 // Loops through an updated app's manifest and creates and links any newly referenced databases.
 // Returns None if the user canceled terminal interaction
 pub(super) async fn create_and_link_databases_for_existing_app(
-    client: &CloudClient,
+    client: &impl CloudClientInterface,
     app_name: &str,
     app_id: Uuid,
     labels: HashSet<String>,
@@ -200,7 +199,7 @@ pub(super) async fn create_and_link_databases_for_existing_app(
 }
 
 pub(super) async fn link_databases(
-    client: &CloudClient,
+    client: &impl CloudClientInterface,
     app_name: String,
     app_id: Uuid,
     database_labels: Vec<(String, String)>,

--- a/src/commands/deploy/database.rs
+++ b/src/commands/deploy/database.rs
@@ -1,0 +1,225 @@
+use anyhow::{bail, Context, Result};
+use cloud::{
+    client::{Client as CloudClient},
+    CloudClientInterface,
+};
+use cloud_openapi::models::{
+    Database,
+    ResourceLabel,
+};
+
+use std::{
+    collections::HashSet,
+};
+use uuid::Uuid;
+
+use crate::{
+    random_name::RandomNameGenerator,
+};
+
+use crate::commands::sqlite::database_has_link;
+
+/// A user's selection of a database to link to a label
+enum DatabaseSelection {
+    Existing(String),
+    New(String),
+    Cancelled,
+}
+
+/// Whether a database has already been linked or not
+enum ExistingAppDatabaseSelection {
+    NotYetLinked(DatabaseSelection),
+    AlreadyLinked,
+}
+
+async fn get_database_selection_for_existing_app(
+    name: &str,
+    client: &CloudClient,
+    resource_label: &ResourceLabel,
+) -> Result<ExistingAppDatabaseSelection> {
+    let databases = client.get_databases(None).await?;
+    if databases
+        .iter()
+        .any(|d| database_has_link(d, &resource_label.label, resource_label.app_name.as_deref()))
+    {
+        return Ok(ExistingAppDatabaseSelection::AlreadyLinked);
+    }
+    let selection = prompt_database_selection(name, &resource_label.label, databases)?;
+    Ok(ExistingAppDatabaseSelection::NotYetLinked(selection))
+}
+
+async fn get_database_selection_for_new_app(
+    name: &str,
+    client: &CloudClient,
+    label: &str,
+) -> Result<DatabaseSelection> {
+    let databases = client.get_databases(None).await?;
+    prompt_database_selection(name, label, databases)
+}
+
+fn prompt_database_selection(
+    name: &str,
+    label: &str,
+    databases: Vec<Database>,
+) -> Result<DatabaseSelection> {
+    let prompt = format!(
+        r#"App "{name}" accesses a database labeled "{label}"
+Would you like to link an existing database or create a new database?"#
+    );
+    let existing_opt = "Use an existing database and link app to it";
+    let create_opt = "Create a new database and link the app to it";
+    let opts = vec![existing_opt, create_opt];
+    let index = match dialoguer::Select::new()
+        .with_prompt(prompt)
+        .items(&opts)
+        .default(1)
+        .interact_opt()?
+    {
+        Some(i) => i,
+        None => return Ok(DatabaseSelection::Cancelled),
+    };
+    match index {
+        0 => prompt_for_existing_database(
+            name,
+            label,
+            databases.into_iter().map(|d| d.name).collect::<Vec<_>>(),
+        ),
+        1 => prompt_link_to_new_database(
+            name,
+            label,
+            databases
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect::<HashSet<_>>(),
+        ),
+        _ => bail!("Choose unavailable option"),
+    }
+}
+
+fn prompt_for_existing_database(
+    name: &str,
+    label: &str,
+    mut database_names: Vec<String>,
+) -> Result<DatabaseSelection> {
+    let prompt =
+        format!(r#"Which database would you like to link to {name} using the label "{label}""#);
+    let index = match dialoguer::Select::new()
+        .with_prompt(prompt)
+        .items(&database_names)
+        .default(0)
+        .interact_opt()?
+    {
+        Some(i) => i,
+        None => return Ok(DatabaseSelection::Cancelled),
+    };
+    Ok(DatabaseSelection::Existing(database_names.remove(index)))
+}
+
+fn prompt_link_to_new_database(
+    name: &str,
+    label: &str,
+    existing_names: HashSet<&str>,
+) -> Result<DatabaseSelection> {
+    let generator = RandomNameGenerator::new();
+    let default_name = generator
+        .generate_unique(existing_names, 20)
+        .context("could not generate unique database name")?;
+
+    let prompt = format!(
+        r#"What would you like to name your database?
+Note: This name is used when managing your database at the account level. The app "{name}" will refer to this database by the label "{label}".
+Other apps can use different labels to refer to the same database."#
+    );
+    let name = dialoguer::Input::new()
+        .with_prompt(prompt)
+        .default(default_name)
+        .interact_text()?;
+    Ok(DatabaseSelection::New(name))
+}
+
+// Loops through an app's manifest and creates databases.
+// Returns a list of database and label pairs that should be
+// linked to the app once it is created.
+// Returns None if the user canceled terminal interaction
+pub(super) async fn create_databases_for_new_app(
+    client: &CloudClient,
+    name: &str,
+    labels: HashSet<String>,
+) -> anyhow::Result<Option<Vec<(String, String)>>> {
+    let mut databases_to_link = Vec::new();
+    for label in labels {
+        let db = match get_database_selection_for_new_app(name, client, &label).await? {
+            DatabaseSelection::Existing(db) => db,
+            DatabaseSelection::New(db) => {
+                client.create_database(db.clone(), None).await?;
+                db
+            }
+            // User canceled terminal interaction
+            DatabaseSelection::Cancelled => return Ok(None),
+        };
+        databases_to_link.push((db, label));
+    }
+    Ok(Some(databases_to_link))
+}
+
+// Loops through an updated app's manifest and creates and links any newly referenced databases.
+// Returns None if the user canceled terminal interaction
+pub(super) async fn create_and_link_databases_for_existing_app(
+    client: &CloudClient,
+    app_name: &str,
+    app_id: Uuid,
+    labels: HashSet<String>,
+) -> anyhow::Result<Option<()>> {
+    for label in labels {
+        let resource_label = ResourceLabel {
+            app_id,
+            label,
+            app_name: Some(app_name.to_string()),
+        };
+        if let ExistingAppDatabaseSelection::NotYetLinked(selection) =
+            get_database_selection_for_existing_app(app_name, client, &resource_label).await?
+        {
+            match selection {
+                // User canceled terminal interaction
+                DatabaseSelection::Cancelled => return Ok(None),
+                DatabaseSelection::New(db) => {
+                    client.create_database(db, Some(resource_label)).await?;
+                }
+                DatabaseSelection::Existing(db) => {
+                    client
+                        .create_database_link(&db, resource_label)
+                        .await
+                        .with_context(|| {
+                            format!(r#"Could not link database "{}" to app "{}""#, db, app_name,)
+                        })?;
+                }
+            }
+        }
+    }
+    Ok(Some(()))
+}
+
+pub(super) async fn link_databases(
+    client: &CloudClient,
+    app_name: String,
+    app_id: Uuid,
+    database_labels: Vec<(String, String)>,
+) -> anyhow::Result<()> {
+    for (database, label) in database_labels {
+        let resource_label = ResourceLabel {
+            label,
+            app_id,
+            app_name: Some(app_name.clone()),
+        };
+        client
+            .create_database_link(&database, resource_label)
+            .await
+            .with_context(|| {
+                format!(
+                    r#"Failed to link database "{}" to app "{}""#,
+                    database, app_name
+                )
+            })?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
This is another take on #125 (cf. #126).  It's significantly more complicated than #126, but aims to be more explicit.

I am not delighted with the CLI experience in this initial draft.  This looks like:

```
spin cloud deploy --link sqlite:default=* --link sqlite:monies=finance
```

Here the `sqlite:` prefix says what the label refers to (to allow for K/V or other resource linking in future), and `*` is a magic symbol for "create a new and link that".  This is a lot more verbose than @kate-goldenring's example syntax in https://github.com/fermyon/cloud-plugin/pull/126#issuecomment-1749763854 and perhaps the future-proofing is too speculative, I'm not sure; and of course magic symbols are never great for discoverability.

That said, I'm optimistic about the principle of using a strategy object, and I think I've separated the CLI parsing reasonably cleanly from the strategy object itself, so maybe we can iterate on this and find an experience that folks are happy with?

(Oh yeah there are a whole lot more tests need writing but the mocks had turned my brain to sausage so I'll do them later.)

