### PR TITLE
Tweak route printing

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1004,10 +1004,6 @@ async fn is_ready(app_info_url: &str, expected_version: &str) -> Result<bool> {
 }
 
 fn print_available_routes(app_name: &str, app_base_url: &Url, base: &str, routes: &[HttpRoute]) {
-    if routes.is_empty() {
-        return;
-    }
-
     // Strip any trailing slash from base URL
     let app_base_url = app_base_url.to_string();
     let route_prefix = app_base_url.strip_suffix('/').unwrap_or(&app_base_url);
@@ -1019,16 +1015,23 @@ fn print_available_routes(app_name: &str, app_base_url: &Url, base: &str, routes
         base.to_owned()
     };
 
-    println!("Available Routes:");
-    for component in routes {
-        let route = RoutePattern::from(&base, &component.route_pattern);
-        println!("  {}: {}{}", component.id, route_prefix, route);
-        if let Some(description) = &component.description {
-            println!("    {}", description);
+    let app_root_url = format!("{route_prefix}{base}");
+    let admin_url = format!("{}app/{app_name}", DEFAULT_CLOUD_URL); // URL already has scheme and /
+
+    println!();
+    println!("View application:   {app_root_url}");
+
+    if routes.iter().any(|r| r.route_pattern != "/...") {
+        println!("  Routes:");
+        for component in routes {
+            let route = RoutePattern::from(&base, &component.route_pattern);
+            println!("  - {}: {}{}", component.id, route_prefix, route);
+            if let Some(description) = &component.description {
+                println!("    {}", description);
+            }
         }
     }
 
-    let admin_url = format!("{}app/{app_name}", DEFAULT_CLOUD_URL); // URL already has scheme and /
     println!("Manage application: {admin_url}");
 }
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -22,10 +22,10 @@ use crate::opts::{
     TOKEN,
 };
 
+use super::DEFAULT_CLOUD_URL;
+
 // this is the client ID registered in the Cloud's backend
 const SPIN_CLIENT_ID: &str = "583e63e9-461f-4fbe-a246-23e0fb1cad10";
-
-const DEFAULT_CLOUD_URL: &str = "https://cloud.fermyon.com/";
 
 /// Log into Fermyon Cloud.
 #[derive(Parser, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,8 @@ use cloud::{
 };
 use uuid::Uuid;
 
+const DEFAULT_CLOUD_URL: &str = "https://cloud.fermyon.com/";
+
 pub(crate) async fn create_cloud_client(deployment_env_id: Option<&str>) -> Result<CloudClient> {
     let login_connection = login_connection(deployment_env_id).await?;
     let connection_config = ConnectionConfig {


### PR DESCRIPTION
Fixes #152.

This shows only "view/manage" if there is a single blanket component, but breaks out the routes display if there are multiple components.  E.g.

```
# Just one blanket route
ivan@hecate:~/testing/dbmadness$ spin cloud deploy
Uploading dbmadness version 0.1.0 to Fermyon Cloud...
Deploying...
Waiting for application to become ready.......... ready

View application:   https://dbmadness-hyi1xhfs.fermyon.app/
Manage application: https://cloud.fermyon.com/app/dbmadness

# Multiple routes
ivan@hecate:~/testing/dbmadness$ spin cloud deploy
Uploading dbmadness version 0.1.0 to Fermyon Cloud...
Deploying...
Waiting for application to become ready.................. ready

View application:   https://dbmadness-hyi1xhfs.fermyon.app/
  Routes:
  - dbmadness: https://dbmadness-hyi1xhfs.fermyon.app (wildcard)
    Absolute madness, you'll laugh, you'll cry. But with DATABASES
  - dbmadness: https://dbmadness-hyi1xhfs.fermyon.app/bibble
    Absolute madness, you'll laugh, you'll cry. But with DATABASES
Manage application: https://cloud.fermyon.com/app/dbmadness
```

This isn't what @flynnduism originally asked for, it's a proposal for an intermediate ground, but I have reservations about whether the "multiple routes" exception is worth it - e.g. if you have an app logic component and an asset fileserver then I'm not sure you care that much what route the fileserver is on...  Anyway up for discussion.

