### PR TITLE
add env_logger crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "comfy-table",
  "dialoguer",
  "dirs 5.0.1",
+ "env_logger",
  "lazy_static",
  "mockall",
  "oci-distribution",
@@ -824,6 +825,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1233,6 +1247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1396,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix 0.38.21",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ terminal = { git = "https://github.com/fermyon/spin", rev = "9672d74122e422cd8c6
 tempfile = "3.3.0"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4"] }
+env_logger = "0.10.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ enum CloudCli {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    env_logger::init();
     let mut app = CloudCli::clap();
     // Plugin should always be invoked from Spin so set binary name accordingly
     app.set_bin_name("spin cloud");


### PR DESCRIPTION
This allows us to trace HTTP requests to Fermyon Cloud using

    export RUST_LOG=trace
    spin cloud deploy