### PR TITLE
add more context to certain errors

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -253,7 +253,8 @@ impl DeployCommand {
 
                 client
                     .add_revision(storage_id.clone(), version.clone())
-                    .await?;
+                    .await
+                    .context(format!("Unable to upload {}", version.clone()))?;
 
                 for kv in self.key_values {
                     client


### PR DESCRIPTION
This allows the Spin CLI to receive more contextual errors which helps with debugging.

Old error format:

```
><> spin deploy
Uploading spin-checklist version 0.1.0 to Fermyon Cloud...
Deploying...
Error: response status code: 404 Not Found
```

New error format:

```
><> spin deploy
Uploading spin-checklist version 0.1.0 to Fermyon Cloud...
Deploying...
Error: Unable to add revision: response status code: 404 Not Found
```