### PR TITLE
fix(apps.rs): fix formatting for description

### DIFF
--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -93,7 +93,7 @@ impl InfoCommand {
         let (current_domain, in_progress_domain) = domains_current_and_in_progress(&app);
 
         println!("Name: {}", &app.name);
-        print_if_present("Description", app.description.as_ref());
+        print_if_present("Description: ", app.description.as_ref());
         print_if_present("URL: https://", current_domain);
         if let Some(domain) = in_progress_domain {
             println!("Validation for {} is in progress", domain);


### PR DESCRIPTION
Fixes formatting of description on `apps info`.

```
$ spin cloud apps info new-rust
Warning: You're using a pre-release version of Spin (2.4.0-pre0). This plugin might not be compatible (supported: >=1.3). Continuing anyway.
Name: new-rust
DescriptionMy new Spin app using the Rust SDK
URL: https://new-rust-oar3balb.fermyon.app
```
->
```
$ spin cloud apps info new-rust
Warning: You're using a pre-release version of Spin (2.4.0-pre0). This plugin might not be compatible (supported: >=1.3). Continuing anyway.
Name: new-rust
Description: My new Spin app using the Rust SDK
URL: https://new-rust-oar3balb.fermyon.app
```