### PR TITLE
upload to separate artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-            name: cloud
+            name: cloud-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
             path: _dist/cloud-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary to Github release
@@ -161,7 +161,8 @@ jobs:
       - name: download release assets
         uses: actions/download-artifact@v4
         with:
-          name: cloud
+          pattern: cloud-*
+          merge-multiple: true
 
       - name: generate checksums
         run: |


### PR DESCRIPTION
#188 bumped up from upload-artifact v3 to v4, which introduces a significant breaking change: uploads to artifacts are now immutable.

See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md