### PR TITLE
use unique names for checksums/plugin manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cloud
+          name: checksums
           path: checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: upload checksums to Github release
@@ -190,7 +190,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cloud
+          name: plugin-manifest
           path: cloud.json
 
       - name: upload plugin manifest to release


### PR DESCRIPTION
Unlike the binary artifacts, these artifact names are not used anywhere in the pipeline. It appears to be there just to ensure we upload these objects to an alternative location.

closes #190