### PR TITLE
fix: remove whitespace from noun

### DIFF
--- a/src/nouns.txt
+++ b/src/nouns.txt
@@ -91,7 +91,7 @@ tangerine
 grapefruit
 rhubarb
 tomato
-boson 
+boson
 quark
 moon
 sun


### PR DESCRIPTION
There was a whitespace after "boson" in `./src/nouns.txt` which broke key-value store generation upon deployment to cloud