### PR TITLE
ci(.github): pin macos runner versions; restore amd64 builds via macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     needs: [lint-rust]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain
@@ -82,7 +82,7 @@ jobs:
     needs: [lint-rust]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             targetDir: "target/aarch64-unknown-linux-gnu/release",
           }
           - {
-              os: "macos-latest",
+              os: "macos-13",
               arch: "amd64",
               wasiSDK: "macos",
               extension: "",
@@ -58,13 +58,13 @@ jobs:
               targetDir: "target/release",
             }
           - {
-              os: "macos-latest",
+              os: "macos-14",
               arch: "aarch64",
               wasiSDK: "macos",
               extension: "",
-              buildArgs: "--target aarch64-apple-darwin",
-              target: "aarch64-apple-darwin",
-              targetDir: "target/aarch64-apple-darwin/release/",
+              buildArgs: "",
+              target: "",
+              targetDir: "target/release",
             }
           - {
               os: "windows-latest",


### PR DESCRIPTION
The 0.9.0 mac amd64 binary was actually built on the aarch64 arch since it used the mutable `macos-latest` runner name, which has since migrated to apple silicon.

- Restore mac amd64 builds via pinning runner to macos-13
- Pin mac aarch64 runner to macos-14

Tested on fork: https://github.com/vdice/cloud-plugin/actions/runs/9650833532; amd64 binary now as expected (`Mach-O 64-bit executable x86_64`).

Will cut an 0.9.1 release of the plugin once this is in.