### PR TITLE
chore(*): 0.9.1 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cloud"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-plugin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 rust-version = "1.76"

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,6 +1,6 @@
 name = "cloud"
 description = "Commands for publishing applications to the Fermyon Cloud."
-version = "0.9.0"
+version = "0.9.1"
 spin_compatibility = ">=1.3"
 license = "Apache-2.0"
 homepage = "https://github.com/fermyon/cloud-plugin"


### PR DESCRIPTION
In anticipation of a 0.9.1 patch release to pull in https://github.com/fermyon/cloud-plugin/pull/205 and fix mac amd64 build