### PR TITLE
chore(.github): bump ubuntu images to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "amd64",
               wasiSDK: "linux",
               extension: "",
@@ -40,7 +40,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-            os: "ubuntu-20.04",
+            os: "ubuntu-22.04",
             arch: "aarch64",
             wasiSDK: "linux",
             extension: "",


### PR DESCRIPTION
Bumps the Ubuntu images to 22.04 per the [deprecation of 20.04](https://github.com/actions/runner-images/issues/11101).